### PR TITLE
Refine layout and allow multi-player shirt filtering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,6 +37,10 @@ body{
   font-size: 1.2rem;
   font-weight: bold;
 }
+.top-bar-left a{
+  text-decoration: none;
+  color: inherit;
+}
 .top-bar-right .nav-link{
   text-decoration: none;
   font-weight: bold;

--- a/css/style2.css
+++ b/css/style2.css
@@ -73,39 +73,6 @@ p {
   line-height: 1.5;
 }
 
-.photo-row,
-.about-me {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-}
-
-.photo-row {
-  gap: 14px;
-}
-
-.photo,
-.about-me .photo {
-  position: relative;
-  flex-basis: calc(50% - 10px);
-  margin-bottom: 20px;
-}
-
-.photo img,
-.about-me .photo img {
-  width: 100%;
-  height: auto;
-  border-radius: 6px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
-  margin: 0 auto;
-  display: block;
-}
-
-.about-me .text {
-  flex-basis: calc(65% - 10px);
-  margin-bottom: 20px;
-}
-
 footer {
   background-color: #333;
   color: #fff;
@@ -115,23 +82,9 @@ footer {
 }
 
 /* Shirt card tweaks */
-.shirt-section {
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  padding: 16px;
-  background: #fff;
-  margin: 16px 20px;
-}
-
 .shirt-section h3 {
   font-size: 18px;
   margin-bottom: 10px;
-}
-
-.player-info {
-  margin-top: 6px;
-  color: #444;
-  font-size: 0.95rem;
 }
 
 a {
@@ -458,21 +411,10 @@ footer:hover {
   text-align: center;
   margin-top: 10px;
   font-weight: bold;
+  color: #444;
+  font-size: 0.95rem;
 }
 .shirt-details { text-align: center; margin-top: 10px; }
-
-/* Filter bar */
-.filter-bar {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin: 16px 0 8px 0;
-}
-.filter-bar input {
-  padding: 8px 10px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-}
 
 /* Lightbox modal */
 .lightbox-overlay {

--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
 
   <!-- Top bar (header) -->
   <header class="top-bar fade-in">
-    <div class="top-bar-left">Matteo De Moor</div>
+    <div class="top-bar-left"><a href="index.html">Matteo De Moor</a></div>
     <div class="top-bar-right">
-      <a href="shirts.html" class="nav-link">See my Football shirt collection</a>
+      <a href="shirts.html" class="nav-link">Shirt Collection</a>
     </div>
   </header>
 

--- a/js/shirts.js
+++ b/js/shirts.js
@@ -100,16 +100,14 @@ function setupFiltering() {
   }
 
   if (playerSel) {
-    const addAll = document.createElement('option');
-    addAll.value = '';
-    addAll.textContent = 'All players';
-    playerSel.appendChild(addAll);
-    Array.from(playersMap.entries()).sort((a,b)=>byAlpha(a[1], b[1])).forEach(([key,label]) => {
-      const opt = document.createElement('option');
-      opt.value = key; // lower-case key
-      opt.textContent = label; // display label
-      playerSel.appendChild(opt);
-    });
+    Array.from(playersMap.entries())
+      .sort((a,b)=>byAlpha(a[1], b[1]))
+      .forEach(([key,label]) => {
+        const opt = document.createElement('option');
+        opt.value = key; // lower-case key
+        opt.textContent = label; // display label
+        playerSel.appendChild(opt);
+      });
   }
 
   function getMultiSelectedValues(selectEl) {
@@ -120,13 +118,13 @@ function setupFiltering() {
     const seasonsSelected = seasonSel ? getMultiSelectedValues(seasonSel) : [];
     const typeValue = (typeSel?.value || '').toLowerCase();
     const sizeValue = (sizeSel?.value || '').toUpperCase();
-    const playerValue = (playerSel?.value || '').toLowerCase();
+    const playersSelected = playerSel ? getMultiSelectedValues(playerSel) : [];
 
     sections.forEach(sec => {
       const okSeason = seasonsSelected.length === 0 || seasonsSelected.includes(sec.dataset.season || '');
       const okType = !typeValue || (sec.dataset.typeBase || '') === typeValue;
       const okSize = !sizeValue || (sec.dataset.size || '') === sizeValue;
-      const okPlayer = !playerValue || (sec.dataset.player || '') === playerValue;
+      const okPlayer = playersSelected.length === 0 || playersSelected.includes(sec.dataset.player || '');
       sec.style.display = (okSeason && okType && okSize && okPlayer) ? '' : 'none';
     });
   }
@@ -140,7 +138,7 @@ function setupFiltering() {
     if (seasonSel) Array.from(seasonSel.options).forEach(o => (o.selected = false));
     if (typeSel) typeSel.value = '';
     if (sizeSel) sizeSel.value = '';
-    if (playerSel) playerSel.value = '';
+    if (playerSel) Array.from(playerSel.options).forEach(o => (o.selected = false));
     applyFilter();
   });
 

--- a/shirts.html
+++ b/shirts.html
@@ -12,8 +12,8 @@
         <script src="js/shirts.js" defer></script>
     </head>
     <body>
-        <header class="top-bar">
-            <div class="top-bar-left"><a href="index.html" class="nav-link" style="background:none;padding:0">Matteo De Moor</a></div>
+        <header class="top-bar fade-in">
+            <div class="top-bar-left"><a href="index.html">Matteo De Moor</a></div>
             <div class="top-bar-right">
               <a href="shirts.html" class="nav-link">Shirt Collection</a>
             </div>
@@ -38,7 +38,7 @@
                   </div>
                   <div class="filter-group">
                     <label for="filter-player">Player</label>
-                    <select id="filter-player" aria-label="Filter by player"></select>
+                    <select id="filter-player" multiple size="6" aria-label="Filter by player"></select>
                   </div>
                   <div class="filter-actions">
                     <button id="filter-clear" class="button"><span class="button_lg"><span class="button_sl"></span><span class="button_text">Clear</span></span></button>


### PR DESCRIPTION
## Summary
- Harmonize navigation bars on home and shirts pages
- Support multi-select filtering by players and seasons
- Clean up duplicate CSS and improve player info styling

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`
- `node --check js/shirts.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6a87e9cd88325a5cc9b0d8d17b200