### PR TITLE
Add navigation links and improved shirt filters

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -41,6 +41,10 @@ body{
   text-decoration: none;
   color: inherit;
 }
+.top-bar-right{
+  display: flex;
+  gap: 10px;
+}
 .top-bar-right .nav-link{
   text-decoration: none;
   font-weight: bold;

--- a/css/style2.css
+++ b/css/style2.css
@@ -22,11 +22,13 @@ section {
 }
 
 /* Filter bar */
+
+/* Filter bar */
 .filter-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px 16px;
-  align-items: end;
+  align-items: flex-end;
   border: 1px solid #e5e7eb;
   background: #fafafa;
   padding: 14px;
@@ -43,7 +45,7 @@ section {
 }
 
 .filter-group select {
-  width: 100%;
+  width: 180px;
   padding: 8px 10px;
   border: 1px solid #cfd8e3;
   border-radius: 6px;
@@ -51,16 +53,22 @@ section {
   font-size: 0.95rem;
 }
 
-.filter-group select[multiple] {
-  min-height: 120px;
-}
+
 
 .filter-actions {
-  grid-column: 1 / -1;
-  display: flex;
-  gap: 10px;
-  justify-content: flex-start;
-  margin-top: 4px;
+  margin-left: auto;
+}
+
+.filter-actions button {
+  padding: 8px 12px;
+  border: 1px solid #cfd8e3;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+}
+
+.filter-actions button:hover {
+  background: #d4ebff;
 }
 
 h2 {
@@ -106,7 +114,8 @@ a:hover {
   }
 
   .filter-bar {
-    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
   }
 
   nav ul {
@@ -232,124 +241,6 @@ footer:hover {
   box-sizing: border-box;
 }
 
-.button {
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-  border: none;
-  background: none;
-  color: #0f1923;
-  cursor: pointer;
-  position: relative;
-  padding: 8px;
-  margin-bottom: 20px;
-  text-transform: uppercase;
-  font-weight: bold;
-  font-size: 14px;
-  transition: all .15s ease;
-}
-
-.button::before,
-.button::after {
-  content: '';
-  display: block;
-  position: absolute;
-  right: 0;
-  left: 0;
-  height: calc(50% - 5px);
-  border: 1px solid #7D8082;
-  transition: all .15s ease;
-}
-
-.button::before {
-  top: 0;
-  border-bottom-width: 0;
-}
-
-.button::after {
-  bottom: 0;
-  border-top-width: 0;
-}
-
-.button:active,
-.button:focus {
-  outline: none;
-}
-
-.button:active::before,
-.button:active::after {
-  right: 3px;
-  left: 3px;
-}
-
-.button:active::before {
-  top: 3px;
-}
-
-.button:active::after {
-  bottom: 3px;
-}
-
-.button_lg {
-  position: relative;
-  display: block;
-  padding: 10px 20px;
-  color: #fff;
-  background-color: #0f1923;
-  overflow: hidden;
-  box-shadow: inset 0px 0px 0px 1px transparent;
-}
-
-.button_lg::before {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 2px;
-  height: 2px;
-  background-color: #0f1923;
-}
-
-.button_lg::after {
-  content: '';
-  display: block;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 4px;
-  height: 4px;
-  background-color: #0f1923;
-  transition: all .2s ease;
-}
-
-.button_sl {
-  display: block;
-  position: absolute;
-  top: 0;
-  bottom: -1px;
-  left: -8px;
-  width: 0;
-  background-color: #ff4655;
-  transform: skew(-15deg);
-  transition: all .2s ease;
-}
-
-.button_text {
-  position: relative;
-}
-
-.button:hover {
-  color: #0f1923;
-}
-
-.button:hover .button_sl {
-  width: calc(100% + 15px);
-}
-
-.button:hover .button_lg::after {
-  background-color: #fff;
-}
 
 .photo img {
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <header class="top-bar fade-in">
     <div class="top-bar-left"><a href="index.html">Matteo De Moor</a></div>
     <div class="top-bar-right">
+      <a href="index.html" class="nav-link">Home</a>
       <a href="shirts.html" class="nav-link">Shirt Collection</a>
     </div>
   </header>

--- a/js/shirts.js
+++ b/js/shirts.js
@@ -74,23 +74,15 @@ function setupFiltering() {
   }
 
   if (typeSel) {
-    const addAll = document.createElement('option');
-    addAll.value = '';
-    addAll.textContent = 'All types';
-    typeSel.appendChild(addAll);
     Array.from(typesBase).sort(byAlpha).forEach(t => {
       const opt = document.createElement('option');
-      opt.value = t; // already normalized (home/away/third/fourth/gk)
+      opt.value = t; // normalized
       opt.textContent = t.charAt(0).toUpperCase() + t.slice(1);
       typeSel.appendChild(opt);
     });
   }
 
   if (sizeSel) {
-    const addAll = document.createElement('option');
-    addAll.value = '';
-    addAll.textContent = 'All sizes';
-    sizeSel.appendChild(addAll);
     sortSizes(sizes).forEach(z => {
       const opt = document.createElement('option');
       opt.value = z;
@@ -116,14 +108,14 @@ function setupFiltering() {
 
   function applyFilter() {
     const seasonsSelected = seasonSel ? getMultiSelectedValues(seasonSel) : [];
-    const typeValue = (typeSel?.value || '').toLowerCase();
-    const sizeValue = (sizeSel?.value || '').toUpperCase();
+    const typesSelected = typeSel ? getMultiSelectedValues(typeSel).map(v => v.toLowerCase()) : [];
+    const sizesSelected = sizeSel ? getMultiSelectedValues(sizeSel).map(v => v.toUpperCase()) : [];
     const playersSelected = playerSel ? getMultiSelectedValues(playerSel) : [];
 
     sections.forEach(sec => {
       const okSeason = seasonsSelected.length === 0 || seasonsSelected.includes(sec.dataset.season || '');
-      const okType = !typeValue || (sec.dataset.typeBase || '') === typeValue;
-      const okSize = !sizeValue || (sec.dataset.size || '') === sizeValue;
+      const okType = typesSelected.length === 0 || typesSelected.includes(sec.dataset.typeBase || '');
+      const okSize = sizesSelected.length === 0 || sizesSelected.includes(sec.dataset.size || '');
       const okPlayer = playersSelected.length === 0 || playersSelected.includes(sec.dataset.player || '');
       sec.style.display = (okSeason && okType && okSize && okPlayer) ? '' : 'none';
     });
@@ -135,10 +127,9 @@ function setupFiltering() {
   });
 
   clearBtn?.addEventListener('click', () => {
-    if (seasonSel) Array.from(seasonSel.options).forEach(o => (o.selected = false));
-    if (typeSel) typeSel.value = '';
-    if (sizeSel) sizeSel.value = '';
-    if (playerSel) Array.from(playerSel.options).forEach(o => (o.selected = false));
+    [seasonSel, typeSel, sizeSel, playerSel].forEach(sel => {
+      if (sel) Array.from(sel.options).forEach(o => (o.selected = false));
+    });
     applyFilter();
   });
 

--- a/python/2_csv_to_html.py
+++ b/python/2_csv_to_html.py
@@ -27,9 +27,10 @@ with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
         <script src="js/shirts.js" defer></script>
     </head>
     <body>
-        <header class="top-bar">
-            <div class="top-bar-left"><a href="index.html" class="nav-link" style="background:none;padding:0">Matteo De Moor</a></div>
+        <header class="top-bar fade-in">
+            <div class="top-bar-left"><a href="index.html">Matteo De Moor</a></div>
             <div class="top-bar-right">
+              <a href="index.html" class="nav-link">Home</a>
               <a href="shirts.html" class="nav-link">Shirt Collection</a>
             </div>
         </header>
@@ -39,11 +40,25 @@ with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
                 <h2>My personal shirt collection</h2>
                 <p>Here you can find my unique Club Brugge shirts collection.</p>
                 <div class="filter-bar" aria-label="Filter shirts">
-                  <input type="text" id="filter-season" placeholder="Season (e.g., 2024-2025)" aria-label="Filter by season" />
-                  <input type="text" id="filter-type" placeholder="Type (Home/Away/Third/GK)" aria-label="Filter by type" />
-                  <input type="text" id="filter-size" placeholder="Size (e.g., M, XL)" aria-label="Filter by size" />
-                  <input type="text" id="filter-player" placeholder="Player (e.g., Vanaken)" aria-label="Filter by player" />
-                  <button id="filter-clear" class="button"><span class="button_lg"><span class="button_sl"></span><span class="button_text">Clear</span></span></button>
+                  <div class="filter-group">
+                    <label for="filter-season">Season</label>
+                    <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
+                  </div>
+                  <div class="filter-group">
+                    <label for="filter-type">Type</label>
+                    <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
+                  </div>
+                  <div class="filter-group">
+                    <label for="filter-size">Size</label>
+                    <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
+                  </div>
+                  <div class="filter-group">
+                    <label for="filter-player">Player</label>
+                    <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
+                  </div>
+                  <div class="filter-actions">
+                    <button id="filter-clear">Clear</button>
+                  </div>
                 </div>
     """
 

--- a/shirts.html
+++ b/shirts.html
@@ -15,6 +15,7 @@
         <header class="top-bar fade-in">
             <div class="top-bar-left"><a href="index.html">Matteo De Moor</a></div>
             <div class="top-bar-right">
+              <a href="index.html" class="nav-link">Home</a>
               <a href="shirts.html" class="nav-link">Shirt Collection</a>
             </div>
         </header>
@@ -26,22 +27,22 @@
                 <div class="filter-bar" aria-label="Filter shirts">
                   <div class="filter-group">
                     <label for="filter-season">Season</label>
-                    <select id="filter-season" multiple size="4" aria-label="Filter by season"></select>
+                    <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
                   </div>
                   <div class="filter-group">
                     <label for="filter-type">Type</label>
-                    <select id="filter-type" aria-label="Filter by type"></select>
+                    <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
                   </div>
                   <div class="filter-group">
                     <label for="filter-size">Size</label>
-                    <select id="filter-size" aria-label="Filter by size"></select>
+                    <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
                   </div>
                   <div class="filter-group">
                     <label for="filter-player">Player</label>
-                    <select id="filter-player" multiple size="6" aria-label="Filter by player"></select>
+                    <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
                   </div>
                   <div class="filter-actions">
-                    <button id="filter-clear" class="button"><span class="button_lg"><span class="button_sl"></span><span class="button_text">Clear</span></span></button>
+                    <button id="filter-clear">Clear</button>
                   </div>
                 </div>
     


### PR DESCRIPTION
## Summary
- Add consistent header navigation with links to Home and Shirt Collection on all pages
- Replace custom filter UI with multi-select fields of equal size and a standard clear button
- Simplify filter logic and cleanup styles; update generator script for new layout

## Testing
- `python -m py_compile python/2_csv_to_html.py`
- `node --check js/shirts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87cab13888325ac56faeca5c36485