### PR TITLE
Add dark 'command' homepage theme, restructure homepage/shirts and update assets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -290,7 +290,10 @@ body.scrolled .top-bar{
   50% { transform: translateY(-6px) rotate(2deg); filter: blur(0.6px); }
   100% { transform: translateY(0) rotate(0deg); filter: blur(0.2px); }
 }
-@media (prefers-reduced-motion: reduce){ .shadow-shape{ animation: none; } }
+@media (prefers-reduced-motion: reduce){
+  .shadow-shape{ animation: none; }
+  .fade-in{ transition: none; }
+}
 .profile-photo{ box-shadow: 0 10px 24px rgba(0,0,0,0.18); }
 
 .subtext{ color: var(--muted); }
@@ -328,3 +331,784 @@ body.scrolled .top-bar{
 .filter-actions button:active{ transform: translateY(1px); }
 
 /* Reveal effect kept only for explicit .fade-in blocks */
+
+/* =====================
+   Data Engineer Command Center homepage
+   ===================== */
+.home-page{
+  --bg: #07111f;
+  --text: #eaf2ff;
+  --muted: #9fb0c8;
+  --card: rgba(12, 25, 45, 0.76);
+  --border: rgba(141, 197, 255, 0.18);
+  --primary: #4cc9ff;
+  --primary-600: #7c5cff;
+  --hover: rgba(76, 201, 255, 0.12);
+  --shadow-md: 0 24px 80px rgba(0, 0, 0, 0.38);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(76, 201, 255, 0.16), transparent 28rem),
+    radial-gradient(circle at 80% 0%, rgba(124, 92, 255, 0.18), transparent 32rem),
+    var(--bg);
+  color: var(--text);
+  overflow-x: hidden;
+}
+
+.home-page .top-bar.command-nav{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 18px clamp(20px, 5vw, 72px);
+  background: rgba(7, 17, 31, 0.72);
+  border-bottom: 1px solid rgba(141, 197, 255, 0.14);
+  box-shadow: none;
+}
+
+.home-page.scrolled .top-bar.command-nav{
+  background: rgba(7, 17, 31, 0.9);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.22);
+}
+
+.home-page .top-bar nav a{
+  background: transparent;
+  color: var(--muted);
+}
+
+.home-page .top-bar nav a:hover,
+.home-page .top-bar nav a.active{
+  color: var(--text);
+  background: transparent;
+}
+
+.command-hero{
+  position: relative;
+  isolation: isolate;
+  min-height: auto;
+  padding: clamp(46px, 6vw, 78px) clamp(20px, 5vw, 72px) 36px;
+  overflow: hidden;
+}
+
+.hero-grid{
+  position: absolute;
+  inset: 0;
+  z-index: -3;
+  background-image:
+    linear-gradient(rgba(141, 197, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(141, 197, 255, 0.08) 1px, transparent 1px);
+  background-size: 54px 54px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.95), transparent 92%);
+}
+
+.hero-glow{
+  position: absolute;
+  z-index: -2;
+  border-radius: 999px;
+  filter: blur(8px);
+  opacity: 0.72;
+}
+
+.hero-glow-one{
+  width: 360px;
+  height: 360px;
+  right: 8%;
+  top: 18%;
+  background: rgba(76, 201, 255, 0.18);
+}
+
+.hero-glow-two{
+  width: 280px;
+  height: 280px;
+  left: 4%;
+  bottom: 12%;
+  background: rgba(124, 92, 255, 0.16);
+}
+
+.command-shell{
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+  align-items: center;
+  gap: clamp(36px, 7vw, 88px);
+  max-width: 1220px;
+  margin: 0 auto;
+}
+
+.hero-copy{
+  max-width: 720px;
+}
+
+.eyebrow{
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 22px;
+  padding: 9px 13px;
+  color: #cfe7ff;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.status-dot{
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #40ffb7;
+  box-shadow: 0 0 18px rgba(64, 255, 183, 0.86);
+}
+
+.hero-copy h1{
+  max-width: 820px;
+  margin-bottom: 24px;
+  font-size: clamp(2.45rem, 5.8vw, 4.9rem);
+  line-height: 0.98;
+  letter-spacing: -0.08em;
+  color: #ffffff;
+}
+
+.hero-lead{
+  max-width: 640px;
+  color: var(--muted);
+  font-size: clamp(1.04rem, 1.5vw, 1.24rem);
+  line-height: 1.75;
+  margin-bottom: 28px;
+}
+
+.hero-actions{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.button{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 800;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.button:hover{
+  transform: translateY(-2px);
+}
+
+.button-primary{
+  color: #06101f;
+  background: linear-gradient(135deg, #78e2ff, #a994ff);
+  box-shadow: 0 18px 42px rgba(76, 201, 255, 0.24);
+}
+
+.button-secondary{
+  color: var(--text);
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.command-social a{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.07);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.command-social a:hover{
+  transform: translateY(-2px);
+  background: rgba(76, 201, 255, 0.12);
+}
+
+.command-social img{
+  width: 18px;
+  filter: invert(1);
+}
+
+.hero-visual{
+  position: relative;
+  min-height: 440px;
+  display: grid;
+  place-items: center;
+}
+
+.profile-card{
+  position: relative;
+  width: min(100%, 420px);
+  padding: 18px 18px 30px;
+  border: 1px solid var(--border);
+  border-radius: 34px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.045)),
+    rgba(11, 24, 43, 0.72);
+  box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  -webkit-backdrop-filter: blur(22px);
+  backdrop-filter: blur(22px);
+}
+
+.card-topline{
+  display: flex;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.card-topline span{
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.card-topline span:first-child{
+  background: #40ffb7;
+}
+
+.command-photo{
+  width: 310px;
+  height: 310px;
+  margin: 0 auto 20px;
+}
+
+.command-photo .shadow-shape{
+  width: 230px;
+  height: 230px;
+  left: 16%;
+  top: 18%;
+  background: radial-gradient(circle, rgba(76, 201, 255, 0.38), rgba(124, 92, 255, 0.24) 48%, transparent 70%);
+  opacity: 1;
+}
+
+.command-photo .profile-photo{
+  width: 310px;
+  height: 310px;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.42);
+}
+
+.command-name{
+  text-align: left;
+  padding: 0 12px;
+}
+
+.role-label{
+  color: var(--primary);
+  font-size: 0.75rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.command-name h2{
+  color: #fff;
+  font-size: clamp(2.35rem, 4vw, 3.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  margin-bottom: 10px;
+}
+
+.command-name .subtext{
+  color: var(--muted);
+}
+
+.stats-bar{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  max-width: 1100px;
+  margin: clamp(32px, 5vw, 58px) auto 0;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.06);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+
+.stats-bar span{
+  padding: 10px 14px;
+  color: #dceeff;
+  border-radius: 999px;
+  background: rgba(76, 201, 255, 0.09);
+  font-weight: 800;
+  font-size: 0.92rem;
+}
+
+.command-panels{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 0 clamp(20px, 5vw, 72px) clamp(56px, 7vw, 92px);
+}
+
+.info-panel{
+  min-height: 220px;
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.18);
+  transition: transform 0.22s ease, border-color 0.22s ease, background-color 0.22s ease;
+}
+
+.info-panel:hover{
+  transform: translateY(-5px);
+  border-color: rgba(76, 201, 255, 0.46);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.panel-kicker{
+  display: inline-block;
+  margin-bottom: 34px;
+  color: var(--primary);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.info-panel h3{
+  margin-bottom: 12px;
+  color: #fff;
+  font-size: 1.35rem;
+}
+
+.info-panel p{
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.command-footer{
+  background: rgba(7, 17, 31, 0.92);
+  border-top: 1px solid rgba(141, 197, 255, 0.14);
+  box-shadow: none;
+}
+
+.command-footer p{
+  color: var(--muted);
+}
+
+@media (max-width: 980px){
+  .command-shell,
+  .command-panels{
+    grid-template-columns: 1fr;
+  }
+
+  .hero-visual{
+    min-height: auto;
+  }
+
+  .profile-card{
+    flex-basis: 100%;
+    max-width: 420px;
+  }
+}
+
+@media (max-width: 600px){
+  .home-page .top-bar.command-nav{
+    padding: 16px 20px;
+  }
+
+  .command-hero{
+    min-height: auto;
+    padding-top: 38px;
+  }
+
+  .hero-copy h1{
+    font-size: clamp(2.45rem, 15vw, 4rem);
+  }
+
+  .command-photo,
+  .command-photo .profile-photo{
+    width: 236px;
+    height: 236px;
+  }
+
+  .command-photo .shadow-shape{
+    width: 176px;
+    height: 176px;
+  }
+
+  .profile-card{
+    border-radius: 26px;
+  }
+
+  .stats-bar{
+    justify-content: flex-start;
+  }
+}
+
+
+
+/* CV content blocks on the command homepage */
+.cv-highlights{
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 0 clamp(20px, 5vw, 72px) clamp(70px, 8vw, 108px);
+}
+
+.section-heading{
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.section-heading h2{
+  color: #fff;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
+  margin-bottom: 14px;
+}
+
+.section-heading p{
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.highlight-grid{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.highlight-card{
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.035)),
+    rgba(255, 255, 255, 0.05);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.highlight-card-wide{
+  grid-column: span 3;
+}
+
+.timeline-date{
+  display: inline-block;
+  margin-bottom: 16px;
+  color: #a9e8ff;
+  font-size: 0.82rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.highlight-card h3{
+  color: #fff;
+  font-size: 1.22rem;
+  margin-bottom: 10px;
+}
+
+.highlight-card p{
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+/* Shirt collection page aligned with command homepage */
+.collection-page main{
+  position: relative;
+  isolation: isolate;
+  padding: clamp(34px, 5vw, 68px) clamp(18px, 4vw, 56px) clamp(56px, 7vw, 88px);
+}
+
+.collection-page main::before{
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(141, 197, 255, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(141, 197, 255, 0.06) 1px, transparent 1px);
+  background-size: 54px 54px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), transparent 88%);
+}
+
+.collection-shell{
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(22px, 4vw, 38px);
+  border: 1px solid var(--border);
+  border-radius: 34px;
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: var(--shadow-md);
+  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: blur(18px);
+}
+
+.collection-page section:hover,
+.collection-page footer:hover{
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.collection-intro{
+  max-width: 760px;
+  margin-bottom: 24px;
+}
+
+.collection-intro h1{
+  color: #fff;
+  font-size: clamp(2.3rem, 5vw, 4.9rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+  margin-bottom: 14px;
+}
+
+.collection-intro p{
+  color: var(--muted);
+  font-size: 1.08rem;
+}
+
+.collection-page .filter-bar{
+  align-items: stretch;
+  gap: 14px;
+  margin: 22px 0 28px;
+  padding: 18px;
+  border-color: rgba(202, 222, 245, 0.95);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(248, 252, 255, 0.96), rgba(222, 239, 255, 0.88));
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+}
+
+.collection-page .filter-group label{
+  color: #0a1a2f;
+}
+
+.collection-page .filter-group select{
+  min-height: 140px;
+  color: #0a1a2f;
+  border-color: rgba(30, 92, 146, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.collection-page .filter-group select option{
+  color: #0a1a2f;
+  background: #ffffff;
+}
+
+.collection-page .filter-actions button{
+  min-height: 42px;
+  color: #ffffff;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #006fbd, #5438d5);
+  font-weight: 800;
+}
+
+.collection-page .shirt-section{
+  align-items: stretch;
+  margin: 24px 0;
+  padding: clamp(18px, 3vw, 30px);
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.035)),
+    rgba(255, 255, 255, 0.045);
+}
+
+.collection-page .shirt-section:hover{
+  background: rgba(255, 255, 255, 0.075);
+  border-color: rgba(76, 201, 255, 0.42);
+}
+
+.collection-page .shirt-section h3{
+  color: #fff;
+  text-align: center;
+  font-size: clamp(1.12rem, 2vw, 1.45rem);
+  margin-bottom: 18px;
+}
+
+.collection-page .photo-row{
+  gap: 20px;
+  margin-bottom: 18px;
+  padding: 20px;
+  border: 1px solid rgba(141, 197, 255, 0.14);
+  border-radius: 22px;
+  background: rgba(7, 17, 31, 0.36);
+}
+
+.collection-page .photo{
+  margin: 0;
+}
+
+.collection-page .photo img{
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 18px;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+}
+
+.collection-page .player-info,
+.collection-page .extra-info,
+.collection-page .collectible-info,
+.collection-page .shirt-details{
+  color: #cfe7ff;
+}
+
+@media (max-width: 980px){
+  .highlight-grid{
+    grid-template-columns: 1fr;
+  }
+
+  .highlight-card-wide{
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 600px){
+  .collection-shell{
+    padding: 18px;
+    border-radius: 24px;
+  }
+
+  .collection-page .filter-bar{
+    flex-direction: column;
+  }
+}
+
+/* Career path and certification snapshot */
+.cv-snapshot-layout{
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.75fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.career-column,
+.certification-column{
+  display: grid;
+  gap: 16px;
+}
+
+.career-card,
+.certification-column{
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.035)),
+    rgba(255, 255, 255, 0.05);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.career-card{
+  position: relative;
+  padding: 24px;
+}
+
+.career-card::before{
+  content: "";
+  position: absolute;
+  left: -1px;
+  top: 24px;
+  width: 3px;
+  height: calc(100% - 48px);
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--primary), var(--primary-600));
+}
+
+.career-card h3,
+.certification-card strong{
+  color: #fff;
+}
+
+.career-card h3{
+  margin-bottom: 10px;
+  font-size: 1.22rem;
+}
+
+.career-card p{
+  color: var(--muted);
+  line-height: 1.68;
+}
+
+.career-card p + p{
+  margin-top: 12px;
+}
+
+.skill-note{
+  color: #cfe7ff !important;
+  font-size: 0.94rem;
+}
+
+.education-card{
+  background:
+    linear-gradient(160deg, rgba(76, 201, 255, 0.14), rgba(124, 92, 255, 0.09)),
+    rgba(255, 255, 255, 0.055);
+}
+
+.certification-column{
+  padding: 24px;
+  position: sticky;
+  top: 96px;
+}
+
+.certification-list{
+  display: grid;
+  gap: 12px;
+}
+
+.certification-card{
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid rgba(141, 197, 255, 0.16);
+  border-radius: 18px;
+  background: rgba(7, 17, 31, 0.38);
+  text-decoration: none;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.certification-card:hover{
+  transform: translateY(-2px);
+  border-color: rgba(76, 201, 255, 0.44);
+  background: rgba(76, 201, 255, 0.1);
+}
+
+.certification-card span{
+  color: var(--primary);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.certification-card strong{
+  line-height: 1.35;
+}
+
+.section-heading code{
+  padding: 2px 7px;
+  border: 1px solid rgba(141, 197, 255, 0.2);
+  border-radius: 999px;
+  color: #dceeff;
+  background: rgba(7, 17, 31, 0.46);
+}
+
+.collection-page .collection-shell{
+  opacity: 1;
+  transform: none;
+}
+
+@media (max-width: 980px){
+  .cv-snapshot-layout{
+    grid-template-columns: 1fr;
+  }
+
+  .certification-column{
+    position: static;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Matteo De Moor</title>
-  <meta name="description" content="Matteo De Moor – final-year Applied Informatics student specialized in Data Science & AI. Portfolio, projects, and football data work." />
-  <meta name="theme-color" content="#ffffff" />
+  <meta name="description" content="Matteo De Moor – Junior Data Engineer specialized in AI & Data Engineering, Microsoft Fabric, Power BI, and football analytics." />
+  <meta name="theme-color" content="#07111f" />
 
   <!-- Open Graph / Twitter -->
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Matteo De Moor – Portfolio" />
-  <meta property="og:description" content="Turning data into insights. Final-year Applied Informatics student focused on Data Science & AI." />
+  <meta property="og:title" content="Matteo De Moor – Data Engineer Portfolio" />
+  <meta property="og:description" content="Building data-driven systems at the intersection of AI, analytics, and football." />
   <meta property="og:image" content="images/Matteo.jpg" />
   <meta property="og:url" content="https://matteodemoor.github.io/" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -19,76 +19,157 @@
   <link rel="stylesheet" href="css/style.css">
   <script src="js/main.js" defer></script>
 </head>
-<body>
+<body class="home-page">
 
   <!-- Top bar (header) -->
-  <header class="top-bar">
+  <header class="top-bar command-nav">
     <nav>
       <a href="index.html">Homepage</a>
       <a href="shirts.html">Shirt Collection</a>
     </nav>
   </header>
 
-  <!-- Main section with photo and name -->
-  <main class="main-content">
-    <!-- Left side: Intro/text -->
-    <section class="intro-left fade-in">
-      <h3>I'm a Junior Data Engineer</h3>
-      <p>In the field of Data Science & AI</p>
-      <br><!-- Extra blank line -->
+  <main>
+    <section class="command-hero">
+      <div class="hero-grid" aria-hidden="true"></div>
+      <div class="hero-glow hero-glow-one" aria-hidden="true"></div>
+      <div class="hero-glow hero-glow-two" aria-hidden="true"></div>
 
-      <!-- Short info about your internship (1 sentence) -->
-      <p>
-      I graduated as a Bachelor in Computer Science, specializing in AI & Data Engineering. Currently, I am starting my professional journey at Agoria as a Junior Data & Engineer, where I am excited to apply my skills in data analysis, machine learning, and artificial intelligence to real-world challenges and contribute to innovative projects.
-      </p>
+      <div class="command-shell fade-in">
+        <div class="hero-copy">
+          <p class="eyebrow"><span class="status-dot"></span> Currently: Junior Data Engineer @ Agoria</p>
+          <h1>Data Engineer for AI, analytics &amp; football.</h1>
+          <p class="hero-lead">
+            I am Matteo De Moor, a <span id="age">22</span>-year-old Applied Computer Science graduate specialized in AI &amp; Data Engineering. I build scalable data pipelines, model datasets, and create clear reporting experiences with Microsoft Fabric, Power BI, Python, SQL, and modern analytics workflows.
+          </p>
 
-      <!-- Download link for your CV -->
-      <div class="download-cv">
-        <a href="file/CV_MatteoDeMoor.pdf" download>Download my CV here!</a>
+          <div class="hero-actions" aria-label="Primary actions">
+            <a class="button button-primary" href="file/CV_MatteoDeMoor.pdf" download>Download CV</a>
+          </div>
+
+          <div class="social-icons command-social" aria-label="Social links">
+            <a href="mailto:matteo.de.moor@skynet.be" aria-label="Email" target="_blank" rel="noopener noreferrer">
+              <img src="images/mail.svg" alt="Email icon">
+            </a>
+            <a href="https://www.linkedin.com/in/matteo-de-moor/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
+              <img src="images/linkedin.svg" alt="LinkedIn icon">
+            </a>
+            <a href="https://github.com/MatteoDeMoor" aria-label="GitHub" target="_blank" rel="noopener noreferrer">
+              <img src="images/github.svg" alt="GitHub icon">
+            </a>
+          </div>
+        </div>
+
+        <div class="hero-visual" aria-label="Matteo De Moor profile visual">
+          <div class="profile-card">
+            <div class="card-topline">
+              <span></span><span></span><span></span>
+            </div>
+            <div class="photo-wrapper command-photo">
+              <div class="shadow-shape"></div>
+              <img src="images/Matteo.jpg" alt="Matteo De Moor" class="profile-photo">
+            </div>
+            <div class="name-text command-name">
+              <p class="role-label">Bachelor's in Applied Computer Science</p>
+              <h2>Matteo<br>De Moor</h2>
+              <p class="subtext">Junior Data Engineer</p>
+            </div>
+          </div>
+        </div>
       </div>
-      
-      <!-- Social icons / links -->
-      <div class="social-icons">
-        <!-- Email -->
-        <a href="mailto:matteo.de.moor@skynet.be"
-           aria-label="Email"
-           target="_blank" rel="noopener noreferrer">
-          <img src="images/mail.svg" alt="Email icon">
-        </a>
-        <!-- LinkedIn -->
-        <a href="https://www.linkedin.com/in/matteo-de-moor/"
-           aria-label="LinkedIn"
-           target="_blank" rel="noopener noreferrer">
-          <img src="images/linkedin.svg" alt="LinkedIn icon">
-        </a>
-        <!-- GitHub -->
-        <a href="https://github.com/MatteoDeMoor"
-           aria-label="GitHub"
-           target="_blank" rel="noopener noreferrer">
-          <img src="images/github.svg" alt="GitHub icon">
-        </a>
+
+      <div class="stats-bar fade-in" aria-label="Profile highlights">
+        <span>Junior Data Engineer @ Agoria</span>
+        <span>Bachelor AI &amp; Data Engineering</span>
+        <span>Football Data Scientist Intern @ Club Brugge</span>
+        <span>Microsoft Fabric · Power BI · Python</span>
       </div>
     </section>
 
-    <!-- Right side: Circular photo with "shadow shape" and name -->
-    <section class="intro-right fade-in">
-      <div class="photo-wrapper">
-        <div class="shadow-shape"></div>
-        <img src="images/Matteo.jpg" alt="Matteo De Moor" class="profile-photo">
+    <section class="command-panels fade-in" aria-label="Professional focus areas">
+      <article class="info-panel">
+        <span class="panel-kicker">01 / Data Engineering</span>
+        <h3>Scalable data foundations</h3>
+        <p>At Agoria, I support scalable data solutions with Microsoft Fabric by building data pipelines, modelling datasets, optimizing analytical workloads, and improving data quality.</p>
+      </article>
+      <article class="info-panel">
+        <span class="panel-kicker">02 / Analytics</span>
+        <h3>Dashboards that explain</h3>
+        <p>I translate complex information into clear dashboards and reports using Power BI, SQL, data warehousing concepts, and structured communication.</p>
+      </article>
+      <article class="info-panel">
+        <span class="panel-kicker">03 / AI &amp; Football</span>
+        <h3>Models with personality</h3>
+        <p>My thesis and Club Brugge internship focused on football analytics, StatsBomb event data, interactive dashboards, and Transformer-based match outcome prediction.</p>
+      </article>
+    </section>
+
+    <section class="cv-highlights fade-in" aria-label="Career path and certifications">
+      <div class="section-heading">
+        <span class="panel-kicker">CV Snapshot</span>
+        <h2>Career path &amp; certifications</h2>
+        <p>A clearer overview of my professional path, bachelor education, and verified certification links.</p>
       </div>
-      <div class="name-text">
-        <h1>Matteo<br>De Moor</h1>
-        <!-- One-liner under your name -->
-        <p class="subtext">Turning data into insights, one model at a time.</p>
+
+      <div class="cv-snapshot-layout">
+        <div class="career-column">
+          <span class="panel-kicker">Career path</span>
+
+          <article class="career-card">
+            <span class="timeline-date">September 2025 · Now</span>
+            <h3>Junior Data Engineer · Agoria</h3>
+            <p>I support the development of scalable data solutions within the Agoria ecosystem, working with Microsoft Fabric to build data pipelines, model datasets, and optimize analytical workloads. I also use Microsoft Power BI to create insightful reports and improve data-driven decision-making.</p>
+          </article>
+
+          <article class="career-card">
+            <span class="timeline-date">August 2025 · September 2025</span>
+            <h3>Junior Data Engineer Student Role · Multiminds</h3>
+            <p>Contributed to the proof of concept of an AI-powered chatbot for the MultiMinds website, focusing on data collection, Q&amp;A generation, and NLP model fine-tuning with Python, Azure Functions, and vector databases.</p>
+          </article>
+
+          <article class="career-card">
+            <span class="timeline-date">February 2025 · May 2025</span>
+            <h3>Football Data Scientist Intern · Club Brugge</h3>
+            <p>Conducted exploratory analyses on StatsBomb event data using Polars, Pandas and MPLSoccer. Built interactive visualizations and a Squad Stability dashboard in Plotly Dash via the SCOUTASTIC API, and validated insights with Hudl Wyscout.</p>
+            <p class="skill-note">Technical skills: Python, Polars, Pandas, Matplotlib, Plotly, Plotly Dash, API integration, Hudl Wyscout workflows and Git.</p>
+          </article>
+
+          <article class="career-card education-card">
+            <span class="timeline-date">September 2022 · June 2025</span>
+            <h3>Bachelor's in Applied Computer Science · HOGENT</h3>
+            <p>Specialisation in AI &amp; Data Engineering. Bachelor thesis: implementation, optimisation and comparative evaluation of a Transformer model to predict the outcome of football matches.</p>
+          </article>
+        </div>
+
+        <aside class="certification-column" aria-label="Certifications">
+          <span class="panel-kicker">Certifications</span>
+          <div class="certification-list">
+            <a class="certification-card" href="https://learn.microsoft.com/en-us/users/matteodemoor-0708/credentials/5c075e7858c80f7f?ref=https%3A%2F%2Fwww.linkedin.com%2F" target="_blank" rel="noopener noreferrer">
+              <span>Microsoft Certified</span>
+              <strong>Azure Data Fundamentals (DP-900)</strong>
+            </a>
+            <a class="certification-card" href="https://learn.microsoft.com/en-gb/users/matteodemoor-0708/credentials/67142d900bebf76c" target="_blank" rel="noopener noreferrer">
+              <span>Microsoft Certified</span>
+              <strong>Azure AI Fundamentals (AI-900)</strong>
+            </a>
+            <a class="certification-card" href="https://learn.microsoft.com/en-gb/users/matteodemoor-0708/credentials/92d663214876e4ca?ref=https%3A%2F%2Fwww.linkedin.com%2F" target="_blank" rel="noopener noreferrer">
+              <span>Microsoft Certified</span>
+              <strong>Azure Fundamentals (AZ-900)</strong>
+            </a>
+            <a class="certification-card" href="https://www.credly.com/badges/e9dfcaac-6b64-46dc-8721-d2163f02fa0b" target="_blank" rel="noopener noreferrer">
+              <span>Credly</span>
+              <strong>Artificial Intelligence Fundamentals</strong>
+            </a>
+          </div>
+        </aside>
       </div>
     </section>
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
+  <footer class="site-footer command-footer">
     <p>&copy; <span id="jaar"></span> Matteo De Moor</p>
   </footer>
 
-  <!-- JS loaded via js/main.js -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       <div class="command-shell fade-in">
         <div class="hero-copy">
           <p class="eyebrow"><span class="status-dot"></span> Currently: Junior Data Engineer @ Agoria</p>
-          <h1>Data Engineer for AI, analytics &amp; football.</h1>
+          <h1>AI &amp; Data Engineering</h1>
           <p class="hero-lead">
             I am Matteo De Moor, a <span id="age">22</span>-year-old Applied Computer Science graduate specialized in AI &amp; Data Engineering. I build scalable data pipelines, model datasets, and create clear reporting experiences with Microsoft Fabric, Power BI, Python, SQL, and modern analytics workflows.
           </p>
@@ -77,13 +77,6 @@
           </div>
         </div>
       </div>
-
-      <div class="stats-bar fade-in" aria-label="Profile highlights">
-        <span>Junior Data Engineer @ Agoria</span>
-        <span>Bachelor AI &amp; Data Engineering</span>
-        <span>Football Data Scientist Intern @ Club Brugge</span>
-        <span>Microsoft Fabric · Power BI · Python</span>
-      </div>
     </section>
 
     <section class="command-panels fade-in" aria-label="Professional focus areas">
@@ -106,7 +99,6 @@
 
     <section class="cv-highlights fade-in" aria-label="Career path and certifications">
       <div class="section-heading">
-        <span class="panel-kicker">CV Snapshot</span>
         <h2>Career path &amp; certifications</h2>
         <p>A clearer overview of my professional path, bachelor education, and verified certification links.</p>
       </div>
@@ -131,7 +123,6 @@
             <span class="timeline-date">February 2025 · May 2025</span>
             <h3>Football Data Scientist Intern · Club Brugge</h3>
             <p>Conducted exploratory analyses on StatsBomb event data using Polars, Pandas and MPLSoccer. Built interactive visualizations and a Squad Stability dashboard in Plotly Dash via the SCOUTASTIC API, and validated insights with Hudl Wyscout.</p>
-            <p class="skill-note">Technical skills: Python, Polars, Pandas, Matplotlib, Plotly, Plotly Dash, API integration, Hudl Wyscout workflows and Git.</p>
           </article>
 
           <article class="career-card education-card">

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const yearEl = document.getElementById('jaar');
   if (yearEl) yearEl.textContent = new Date().getFullYear();
 
+
+  // Dynamically calculate age from date of birth (16 April 2004)
+  const ageEl = document.getElementById('age');
+  if (ageEl) {
+    const today = new Date();
+    let age = today.getFullYear() - 2004;
+    const birthdayThisYear = new Date(today.getFullYear(), 3, 16);
+    if (today < birthdayThisYear) age -= 1;
+    ageEl.textContent = age;
+  }
+
   // Sticky header shadow on scroll
   const onScroll = () => {
     if (window.scrollY > 8) document.body.classList.add('scrolled');

--- a/python/2_csv_to_html.py
+++ b/python/2_csv_to_html.py
@@ -21,14 +21,14 @@ with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Shirt Collection - Matteo De Moor</title>
         <meta name="description" content="Browse Matteo De Moor’s unique Club Brugge football shirt collection with photos, seasons, sizes, and players." />
-        <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/style2.css">
+        <link rel="stylesheet" href="css/style.css">
         <link rel="icon" href="./images/ai2.png" type="image/x-icon">
         <script src="js/main.js" defer></script>
         <script src="js/shirts.js" defer></script>
     </head>
-    <body>
-        <header class="top-bar">
+    <body class="home-page collection-page">
+        <header class="top-bar command-nav">
           <nav>
             <a href="index.html">Homepage</a>
             <a href="shirts.html">Shirt Collection</a>
@@ -36,9 +36,12 @@ with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
         </header>
 
         <main>
-            <section>
-                <h2>My personal shirt collection</h2>
-                <p>Here you can find my unique Club Brugge shirts collection.</p>
+            <section class="collection-shell">
+                <div class="collection-intro">
+                  <span class="panel-kicker">Club Brugge archive</span>
+                  <h1>My personal shirt collection</h1>
+                  <p>Here you can find my unique Club Brugge shirts collection.</p>
+                </div>
                 <div class="filter-bar" aria-label="Filter shirts">
                   <div class="filter-group">
                     <label for="filter-season">Season</label>
@@ -146,6 +149,9 @@ with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
     html_content += """
             </section>
         </main>
+        <footer class="site-footer command-footer">
+          <p>&copy; <span id="jaar"></span> Matteo De Moor</p>
+        </footer>
     </body>
     </html>
     """

--- a/shirts.html
+++ b/shirts.html
@@ -6,14 +6,14 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Shirt Collection - Matteo De Moor</title>
         <meta name="description" content="Browse Matteo De Moor’s unique Club Brugge football shirt collection with photos, seasons, sizes, and players." />
-        <link rel="stylesheet" href="css/style.css">
         <link rel="stylesheet" href="css/style2.css">
+        <link rel="stylesheet" href="css/style.css">
         <link rel="icon" href="./images/ai2.png" type="image/x-icon">
         <script src="js/main.js" defer></script>
         <script src="js/shirts.js" defer></script>
     </head>
-    <body>
-        <header class="top-bar">
+    <body class="home-page collection-page">
+        <header class="top-bar command-nav">
           <nav>
             <a href="index.html">Homepage</a>
             <a href="shirts.html">Shirt Collection</a>
@@ -21,9 +21,12 @@
         </header>
 
         <main>
-            <section>
-                <h2>My personal shirt collection</h2>
-                <p>Here you can find my unique Club Brugge shirts collection.</p>
+            <section class="collection-shell">
+                <div class="collection-intro">
+                  <span class="panel-kicker">Club Brugge archive</span>
+                  <h1>My personal shirt collection</h1>
+                  <p>Here you can find my unique Club Brugge shirts collection.</p>
+                </div>
                 <div class="filter-bar" aria-label="Filter shirts">
                   <div class="filter-group">
                     <label for="filter-season">Season</label>
@@ -2435,6 +2438,9 @@
         
             </section>
         </main>
+        <footer class="site-footer command-footer">
+          <p>&copy; <span id="jaar"></span> Matteo De Moor</p>
+        </footer>
     </body>
     </html>
     


### PR DESCRIPTION
### Motivation
- Replace the simple portfolio landing with a focused Data Engineer "command" homepage and unified dark visual language to better present professional profile, skills and certifications.
- Align the shirt collection pages and generator output with the new visual theme and shared components for consistency across the site.

### Description
- Introduced a large new `.home-page` / `command-*` CSS theme in `css/style.css` with hero, profile-card, stats, panels, collection and CV snapshot styles and accessibility-aware motion reduction handling.
- Reworked `index.html` to use the new layout and markup (hero copy, profile card, stats bar, command panels, CV snapshot and updated meta tags) and added `command-nav` header and `command-footer` footer classes.
- Updated `shirts.html` and the CSV-to-HTML generator `python/2_csv_to_html.py` to emit the new `collection-page` layout, include the unified stylesheet ordering, new filter bar markup, and add the site footer markup.
- Extended `js/main.js` to compute and inject a dynamic age into the page, keep the dynamic year logic, and retain scroll, nav-active and intersection reveal logic.

### Testing
- Executed the generator with `python3 python/2_csv_to_html.py` to regenerate `shirts.html`, which completed successfully and printed the generation message.
- No additional automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0785688e888325bb784681e6a1be74)