### PR TITLE
Improve static SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,21 +3,72 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Matteo De Moor</title>
-  <meta name="description" content="Matteo De Moor – Junior Data Engineer specialized in AI & Data Engineering, Microsoft Fabric, Power BI, and football analytics." />
+  <title>Matteo De Moor – Junior Data Engineer Portfolio</title>
+  <meta name="description" content="Matteo De Moor – Junior Data Engineer specialized in AI &amp; Data Engineering, Microsoft Fabric, Power BI, Python, SQL, and football analytics." />
+  <meta name="robots" content="index, follow" />
   <meta name="theme-color" content="#07111f" />
+  <link rel="canonical" href="https://matteodemoor.github.io/" />
 
   <!-- Open Graph / Twitter -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Matteo De Moor – Data Engineer Portfolio" />
   <meta property="og:description" content="Building data-driven systems at the intersection of AI, analytics, and football." />
-  <meta property="og:image" content="images/Matteo.jpg" />
+  <meta property="og:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
   <meta property="og:url" content="https://matteodemoor.github.io/" />
   <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Matteo De Moor – Data Engineer Portfolio" />
+  <meta name="twitter:description" content="Building data-driven systems at the intersection of AI, analytics, and football." />
+  <meta name="twitter:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
 
   <link rel="icon" href="images/ai2.png" type="image/png">
   <link rel="stylesheet" href="css/style.css">
   <script src="js/main.js" defer></script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Person",
+          "@id": "https://matteodemoor.github.io/#person",
+          "name": "Matteo De Moor",
+          "url": "https://matteodemoor.github.io/",
+          "image": "https://matteodemoor.github.io/images/Matteo.jpg",
+          "jobTitle": "Junior Data Engineer",
+          "worksFor": {
+            "@type": "Organization",
+            "name": "Agoria"
+          },
+          "alumniOf": {
+            "@type": "CollegeOrUniversity",
+            "name": "HOGENT"
+          },
+          "knowsAbout": [
+            "AI & Data Engineering",
+            "Microsoft Fabric",
+            "Power BI",
+            "Python",
+            "SQL",
+            "Football analytics"
+          ],
+          "sameAs": [
+            "https://www.linkedin.com/in/matteo-de-moor/",
+            "https://github.com/MatteoDeMoor"
+          ]
+        },
+        {
+          "@type": "WebSite",
+          "@id": "https://matteodemoor.github.io/#website",
+          "url": "https://matteodemoor.github.io/",
+          "name": "Matteo De Moor",
+          "description": "Portfolio of Matteo De Moor, Junior Data Engineer specialized in AI, data engineering, analytics, and football analytics.",
+          "publisher": {
+            "@id": "https://matteodemoor.github.io/#person"
+          },
+          "inLanguage": "en"
+        }
+      ]
+    }
+  </script>
 </head>
 <body class="home-page">
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://matteodemoor.github.io/sitemap.xml

--- a/shirts.html
+++ b/shirts.html
@@ -4,13 +4,69 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Shirt Collection - Matteo De Moor</title>
-        <meta name="description" content="Browse Matteo De Moor’s unique Club Brugge football shirt collection with photos, seasons, sizes, and players." />
+        <title>Club Brugge Shirt Collection – Matteo De Moor</title>
+        <meta name="description" content="Browse Matteo De Moor’s Club Brugge football shirt collection with photos, seasons, sizes, players, matchworn shirts, and signed shirts." />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href="https://matteodemoor.github.io/shirts.html" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
+        <meta property="og:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
+        <meta property="og:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
+        <meta property="og:url" content="https://matteodemoor.github.io/shirts.html" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
+        <meta name="twitter:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
+        <meta name="twitter:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
         <link rel="stylesheet" href="css/style2.css">
         <link rel="stylesheet" href="css/style.css">
         <link rel="icon" href="./images/ai2.png" type="image/x-icon">
         <script src="js/main.js" defer></script>
         <script src="js/shirts.js" defer></script>
+        <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "CollectionPage",
+                "@id": "https://matteodemoor.github.io/shirts.html#collection",
+                "url": "https://matteodemoor.github.io/shirts.html",
+                "name": "Club Brugge Shirt Collection – Matteo De Moor",
+                "description": "A personal archive of Club Brugge football shirts with photos, seasons, sizes, players, matchworn shirts, and signed shirts.",
+                "isPartOf": {
+                  "@id": "https://matteodemoor.github.io/#website"
+                },
+                "author": {
+                  "@id": "https://matteodemoor.github.io/#person"
+                },
+                "about": [
+                  "Club Brugge",
+                  "Football shirts",
+                  "Matchworn shirts",
+                  "Signed shirts"
+                ],
+                "inLanguage": "en"
+              },
+              {
+                "@type": "BreadcrumbList",
+                "@id": "https://matteodemoor.github.io/shirts.html#breadcrumb",
+                "itemListElement": [
+                  {
+                    "@type": "ListItem",
+                    "position": 1,
+                    "name": "Home",
+                    "item": "https://matteodemoor.github.io/"
+                  },
+                  {
+                    "@type": "ListItem",
+                    "position": 2,
+                    "name": "Shirt Collection",
+                    "item": "https://matteodemoor.github.io/shirts.html"
+                  }
+                ]
+              }
+            ]
+          }
+        </script>
     </head>
     <body class="home-page collection-page">
         <header class="top-bar command-nav">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://matteodemoor.github.io/</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://matteodemoor.github.io/shirts.html</loc>
+    <lastmod>2026-05-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Improve the site’s discoverability by search engines and social previews without changing visible layout or content. 
- Provide canonical URLs, crawl directives and machine-readable metadata so crawlers and social platforms can index and render previews correctly. 
- Surface structured data for the person/site and the shirts collection to help rich results and breadcrumb interpretation.

### Description
- Update `index.html` to add a more descriptive `<title>` and `<meta name="description">`, a `robots` tag, a canonical URL, absolute Open Graph image URLs, Twitter metadata, and a JSON-LD block describing the `Person` and `WebSite` entities. 
- Update `shirts.html` to add a collection-focused `<title>` and `<meta name="description">`, `robots` tag, canonical URL, Open Graph/Twitter metadata, and a JSON-LD block for the `CollectionPage` plus a `BreadcrumbList`. 
- Add a root `robots.txt` that allows crawling and points to the sitemap, and add `sitemap.xml` listing the homepage and `shirts.html` so search engines can discover those pages.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/indexing issues and it passed. 
- Executed an automated Python validation that parsed the updated HTML and confirmed JSON-LD blocks are present and valid JSON, and it succeeded. 
- Validated `sitemap.xml` as well-formed XML and verified `robots.txt` contains the `Sitemap:` line, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079e87a14483258cb0230b5fdddc4a)