### PR TITLE
Improve shirt collection SEO metadata

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -873,6 +873,12 @@ body.scrolled .top-bar{
   font-size: 1.08rem;
 }
 
+.collection-page .collection-meta{
+  margin-top: 14px;
+  color: #cfe7ff;
+  font-size: 0.98rem;
+}
+
 .collection-page .filter-bar{
   align-items: stretch;
   gap: 14px;
@@ -954,6 +960,25 @@ body.scrolled .top-bar{
 .collection-page .collectible-info,
 .collection-page .shirt-details{
   color: #cfe7ff;
+}
+
+.collection-page .shirt-metadata{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 14px;
+  margin: 16px 0 0;
+  color: #cfe7ff;
+  font-size: 0.9rem;
+}
+
+.collection-page .shirt-metadata dt{
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.collection-page .shirt-metadata dd{
+  margin: 0;
 }
 
 @media (max-width: 980px){

--- a/python/2_csv_to_html.py
+++ b/python/2_csv_to_html.py
@@ -1,204 +1,410 @@
 import csv
+import html
+import json
 from pathlib import Path
 
-base_dir = Path(__file__).resolve().parents[1]
-csv_file_path = base_dir / 'csv' / 'shirts.csv'
+BASE_URL = "https://matteodemoor.github.io"
+SITE_NAME = "Matteo De Moor"
+COLLECTION_URL = f"{BASE_URL}/shirts.html"
+DEFAULT_IMAGE = f"{BASE_URL}/images/Matteo.jpg"
+TEAM_NAME = "Club Brugge"
+TEAM_SAME_AS = "https://www.clubbrugge.be/"
 
-# Open the CSV file
-with open(csv_file_path, newline='', encoding='utf-8') as csvfile:
+base_dir = Path(__file__).resolve().parents[1]
+csv_file_path = base_dir / "csv" / "shirts.csv"
+output_path = base_dir / "shirts.html"
+
+
+def clean(value):
+    return (value or "").strip()
+
+
+def esc(value):
+    return html.escape(clean(value), quote=True)
+
+
+def absolute_image(filename):
+    filename = clean(filename)
+    return f"{BASE_URL}/shirtImages/{filename}" if filename else ""
+
+
+def local_image(filename):
+    filename = clean(filename)
+    return f"./shirtImages/{filename}" if filename else ""
+
+
+def unique_case_insensitive(values):
+    unique = {}
+    for value in values:
+        value = clean(value)
+        if value:
+            unique.setdefault(value.casefold(), value)
+    return sorted(unique.values(), key=str.casefold)
+
+
+def first_image(row):
+    for key in ("Foto1", "Foto2", "Foto3"):
+        image = absolute_image(row.get(key, ""))
+        if image:
+            return image
+    return DEFAULT_IMAGE
+
+
+def shirt_name(row):
+    season = clean(row.get("Seizoen"))
+    shirt_type = clean(row.get("Shirt"))
+    player = clean(row.get("Speler"))
+    number = clean(row.get("Nummer"))
+    base = f"{TEAM_NAME} {season} {shirt_type} shirt"
+    if player and number:
+        return f"{base} - {player} #{number}"
+    if player:
+        return f"{base} - {player}"
+    if number:
+        return f"{base} - #{number}"
+    return base
+
+
+def shirt_description(row):
+    parts = [shirt_name(row)]
+    size = clean(row.get("Maat"))
+    extra = clean(row.get("Extra"))
+    signatures = clean(row.get("Handtekeningen"))
+    if size:
+        parts.append(f"Size {size}")
+    if extra:
+        parts.append(extra)
+    if signatures:
+        parts.append(f"signed by {signatures}")
+    return ", ".join(parts) + "."
+
+
+def build_schema(rows, players, seasons, shirt_types):
+    item_list = []
+    for position, row in enumerate(rows, start=1):
+        row_id = clean(row.get("ID"))
+        item_url = f"{COLLECTION_URL}#shirt-{row_id}"
+        player = clean(row.get("Speler"))
+        images = [absolute_image(row.get(key, "")) for key in ("Foto1", "Foto2", "Foto3")]
+        images = [image for image in images if image]
+        item = {
+            "@type": "ListItem",
+            "position": position,
+            "url": item_url,
+            "item": {
+                "@type": "Product",
+                "@id": item_url,
+                "name": shirt_name(row),
+                "description": shirt_description(row),
+                "category": "Football shirt",
+                "brand": {
+                    "@type": "SportsTeam",
+                    "name": TEAM_NAME,
+                    "sameAs": TEAM_SAME_AS,
+                },
+                "image": images or [DEFAULT_IMAGE],
+                "additionalProperty": [
+                    {"@type": "PropertyValue", "name": "Season", "value": clean(row.get("Seizoen"))},
+                    {"@type": "PropertyValue", "name": "Shirt type", "value": clean(row.get("Shirt"))},
+                    {"@type": "PropertyValue", "name": "Size", "value": clean(row.get("Maat"))},
+                ],
+            },
+        }
+        if player:
+            item["item"]["about"] = {"@type": "Person", "name": player}
+        if clean(row.get("Nummer")):
+            item["item"]["additionalProperty"].append(
+                {"@type": "PropertyValue", "name": "Squad number", "value": clean(row.get("Nummer"))}
+            )
+        if clean(row.get("Extra")):
+            item["item"]["additionalProperty"].append(
+                {"@type": "PropertyValue", "name": "Collectible status", "value": clean(row.get("Extra"))}
+            )
+        if clean(row.get("Handtekeningen")):
+            item["item"]["additionalProperty"].append(
+                {"@type": "PropertyValue", "name": "Signatures", "value": clean(row.get("Handtekeningen"))}
+            )
+        item_list.append(item)
+
+    graph = [
+        {
+            "@type": "CollectionPage",
+            "@id": f"{COLLECTION_URL}#collection",
+            "url": COLLECTION_URL,
+            "name": "Club Brugge Shirt Collection – Matteo De Moor",
+            "headline": "Club Brugge football shirt collection with players, seasons and matchworn shirts",
+            "description": "A personal searchable archive of Club Brugge football shirts with photos, seasons, sizes, player names, shirt numbers, matchworn shirts and signed shirts.",
+            "isPartOf": {"@id": f"{BASE_URL}/#website"},
+            "publisher": {"@id": f"{BASE_URL}/#person"},
+            "about": [
+                {"@type": "SportsTeam", "name": TEAM_NAME, "sameAs": TEAM_SAME_AS},
+                "Club Brugge shirts",
+                "Football shirts",
+                "Matchworn football shirts",
+                "Signed football shirts",
+                *players[:25],
+            ],
+            "keywords": [
+                "Club Brugge shirt collection",
+                "Club Brugge football shirts",
+                "Club Brugge matchworn shirt",
+                "Club Brugge signed shirt",
+                *players,
+                *seasons,
+                *shirt_types,
+            ],
+            "primaryImageOfPage": {"@type": "ImageObject", "url": first_image(rows[0]) if rows else DEFAULT_IMAGE},
+            "inLanguage": "en",
+        },
+        {
+            "@type": "BreadcrumbList",
+            "@id": f"{COLLECTION_URL}#breadcrumb",
+            "itemListElement": [
+                {"@type": "ListItem", "position": 1, "name": "Home", "item": f"{BASE_URL}/"},
+                {"@type": "ListItem", "position": 2, "name": "Shirt Collection", "item": COLLECTION_URL},
+            ],
+        },
+        {
+            "@type": "ItemList",
+            "@id": f"{COLLECTION_URL}#shirt-list",
+            "name": "Club Brugge shirts by Matteo De Moor",
+            "numberOfItems": len(rows),
+            "itemListOrder": "https://schema.org/ItemListOrderDescending",
+            "itemListElement": item_list,
+        },
+    ]
+    return {"@context": "https://schema.org", "@graph": graph}
+
+
+with open(csv_file_path, newline="", encoding="utf-8") as csvfile:
     reader = csv.DictReader(csvfile)
-    
-    # Collect all rows into a list and reverse them (so newest appear first)
     rows = list(reader)
     rows.reverse()
 
-    # Start the HTML content
-    html_content = """
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+players = unique_case_insensitive(row.get("Speler", "") for row in rows)
+seasons = unique_case_insensitive(row.get("Seizoen", "") for row in rows)
+shirt_types = unique_case_insensitive(row.get("Shirt", "") for row in rows)
+collectible_statuses = unique_case_insensitive(row.get("Extra", "") for row in rows)
 
-        <title>Club Brugge Shirt Collection – Matteo De Moor</title>
+player_keyword_preview = ", ".join(players[:18])
+keyword_content = ", ".join(
+    [
+        "Club Brugge shirts",
+        "Club Brugge shirt collection",
+        "Club Brugge matchworn shirts",
+        "Club Brugge signed shirts",
+        "football shirt collection",
+        *players,
+        *seasons,
+        *shirt_types,
+        *collectible_statuses,
+    ]
+)
+meta_description = (
+    f"Browse Matteo De Moor's searchable Club Brugge football shirt collection: {len(rows)} shirts with photos, "
+    f"seasons, sizes, shirt numbers, matchworn and signed shirts, including players such as {player_keyword_preview}."
+)
+social_description = (
+    "A searchable personal archive of Club Brugge football shirts with photos, seasons, shirt numbers, "
+    "player names, matchworn shirts and signed shirts."
+)
+schema_json = json.dumps(build_schema(rows, players, seasons, shirt_types), ensure_ascii=False, indent=8)
+page_image = first_image(rows[0]) if rows else DEFAULT_IMAGE
 
-        <meta name="description" content="Browse Matteo De Moor’s Club Brugge football shirt collection with photos, seasons, sizes, players, matchworn shirts, and signed shirts." />
+html_content = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <meta name="robots" content="index, follow" />
+    <title>Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor</title>
 
-        <link rel="canonical" href="https://matteodemoor.github.io/shirts.html" />
+    <meta name="description" content="{esc(meta_description)}" />
+    <meta name="keywords" content="{esc(keyword_content)}" />
+    <meta name="author" content="Matteo De Moor" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 
-        <!-- Open Graph -->
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
-        <meta property="og:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
-        <meta property="og:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
-        <meta property="og:url" content="https://matteodemoor.github.io/shirts.html" />
+    <link rel="canonical" href="{COLLECTION_URL}" />
 
-        <!-- Twitter -->
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
-        <meta name="twitter:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
-        <meta name="twitter:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="{SITE_NAME}" />
+    <meta property="og:title" content="Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor" />
+    <meta property="og:description" content="{esc(social_description)}" />
+    <meta property="og:image" content="{page_image}" />
+    <meta property="og:image:alt" content="Club Brugge football shirt from Matteo De Moor's collection" />
+    <meta property="og:url" content="{COLLECTION_URL}" />
+    <meta property="og:locale" content="en_US" />
 
-        <link rel="stylesheet" href="css/style2.css">
-        <link rel="stylesheet" href="css/style.css">
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor" />
+    <meta name="twitter:description" content="{esc(social_description)}" />
+    <meta name="twitter:image" content="{page_image}" />
+    <meta name="twitter:image:alt" content="Club Brugge football shirt from Matteo De Moor's collection" />
 
-        <link rel="icon" href="./images/ai2.png" type="image/x-icon">
+    <link rel="stylesheet" href="css/style2.css">
+    <link rel="stylesheet" href="css/style.css">
 
-        <script src="js/main.js" defer></script>
-        <script src="js/shirts.js" defer></script>
+    <link rel="icon" href="./images/ai2.png" type="image/x-icon">
 
-        <script type="application/ld+json">
-        {
-        "@context": "https://schema.org",
-        "@graph": [
-            {
-            "@type": "CollectionPage",
-            "@id": "https://matteodemoor.github.io/shirts.html#collection",
-            "url": "https://matteodemoor.github.io/shirts.html",
-            "name": "Club Brugge Shirt Collection – Matteo De Moor",
-            "description": "A personal archive of Club Brugge football shirts with photos, seasons, sizes, players, matchworn shirts, and signed shirts.",
-            "about": [
-                "Club Brugge",
-                "Football shirts",
-                "Matchworn shirts",
-                "Signed shirts"
-            ],
-            "inLanguage": "en"
-            }
-        ]
-        }
-        </script>
-    </head>
-    <body class="home-page collection-page">
-        <header class="top-bar command-nav">
-          <nav>
-            <a href="index.html">Homepage</a>
-            <a href="shirts.html">Shirt Collection</a>
-          </nav>
-        </header>
+    <script src="js/main.js" defer></script>
+    <script src="js/shirts.js" defer></script>
 
-        <main>
-            <section class="collection-shell">
-                <div class="collection-intro">
-                    <span class="panel-kicker">Club Brugge archive</span>
-                    <h1>My personal shirt collection</h1>
-                    <p>Here you can find my unique Club Brugge shirts collection.</p>
-                </div>
-                <div class="filter-bar" aria-label="Filter shirts">
-                  <div class="filter-group">
-                    <label for="filter-season">Season</label>
-                    <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="filter-type">Type</label>
-                    <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
-                  </div>
-                <div class="filter-group">
-                    <label for="filter-size">Size</label>
-                    <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="filter-collectible">Collectible</label>
-                    <select id="filter-collectible" multiple size="5" aria-label="Filter by collectible status"></select>
-                  </div>
-                  <div class="filter-group filter-group--player">
-                    <label for="filter-player">Player</label>
-                    <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
-                  </div>
-                  <div class="filter-actions">
-                    <button id="filter-clear">Clear</button>
-                  </div>
-                </div>
-    """
+    <script type="application/ld+json">
+{schema_json}
+    </script>
+</head>
+<body class="home-page collection-page">
+    <header class="top-bar command-nav">
+      <nav>
+        <a href="index.html">Homepage</a>
+        <a href="shirts.html">Shirt Collection</a>
+      </nav>
+    </header>
 
-    # Counter for shirts
-    shirt_counter = 1
+    <main>
+        <section class="collection-shell" itemscope itemtype="https://schema.org/CollectionPage">
+            <div class="collection-intro">
+                <span class="panel-kicker">Club Brugge archive</span>
+                <h1 itemprop="name">My personal Club Brugge shirt collection</h1>
+                <p itemprop="description">Here you can find my unique, searchable Club Brugge shirts collection with player names, shirt numbers, seasons, sizes, matchworn shirts and signed shirts.</p>
+                <p class="collection-meta">This archive contains {len(rows)} Club Brugge shirts across {len(seasons)} seasons and {len(players)} named players, including {esc(player_keyword_preview)}.</p>
+            </div>
+            <div class="filter-bar" aria-label="Filter shirts">
+              <div class="filter-group">
+                <label for="filter-season">Season</label>
+                <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-type">Type</label>
+                <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-size">Size</label>
+                <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-collectible">Collectible</label>
+                <select id="filter-collectible" multiple size="5" aria-label="Filter by collectible status"></select>
+              </div>
+              <div class="filter-group filter-group--player">
+                <label for="filter-player">Player</label>
+                <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
+              </div>
+              <div class="filter-actions">
+                <button id="filter-clear">Clear</button>
+              </div>
+            </div>
+"""
 
-    # Loop through each row in the CSV
-    for row in rows:
-        shirt_team       = "Club Brugge"  # hardcoded
-        shirt_season     = row['Seizoen']
-        shirt_type       = row['Shirt']
-        shirt_size       = row['Maat']
-        shirt_player     = row['Speler']
-        shirt_number     = row['Nummer']
-        shirt_extra      = row['Extra']
-        shirt_signatures = row['Handtekeningen']
+shirt_counter = 1
 
-        # Construct paths for the photos (if present)
-        image1 = f"./shirtImages/{row['Foto1']}" if row['Foto1'] else ""
-        image2 = f"./shirtImages/{row['Foto2']}" if row['Foto2'] else ""
-        image3 = f"./shirtImages/{row['Foto3']}" if row['Foto3'] else ""
-        
-        # Start HTML for this shirt section
-        collectible_value = (shirt_extra or "").strip().lower()
-        collectible_attr = f' data-collectible="{collectible_value}"' if collectible_value else ""
+for row in rows:
+    shirt_team = TEAM_NAME
+    shirt_id = clean(row["ID"])
+    shirt_season = clean(row["Seizoen"])
+    shirt_type = clean(row["Shirt"])
+    shirt_size = clean(row["Maat"])
+    shirt_player = clean(row["Speler"])
+    shirt_number = clean(row["Nummer"])
+    shirt_extra = clean(row["Extra"])
+    shirt_signatures = clean(row["Handtekeningen"])
 
-        html_content += f"""
-        <!-- Shirt {shirt_counter} (ID: {row['ID']}) -->
-        <div class="shirt-section"{collectible_attr}>
-            <h3>{shirt_team} {shirt_season} {shirt_type} - Size: {shirt_size}</h3>
+    image1 = local_image(row["Foto1"])
+    image2 = local_image(row["Foto2"])
+    image3 = local_image(row["Foto3"])
+    images = [image for image in (image1, image2, image3) if image]
+
+    collectible_value = shirt_extra.lower()
+    collectible_attr = f' data-collectible="{esc(collectible_value)}"' if collectible_value else ""
+    player_attr = f' data-player="{esc(shirt_player.lower())}"' if shirt_player else ""
+    section_id = f"shirt-{esc(shirt_id)}"
+    title = shirt_name(row)
+    title_with_size = f"{title} - Size: {shirt_size}" if shirt_size else title
+    article_keywords = ", ".join(filter(None, [shirt_team, shirt_season, shirt_type, shirt_player, shirt_number, shirt_extra]))
+
+    html_content += f"""
+        <!-- Shirt {shirt_counter} (ID: {esc(shirt_id)}) -->
+        <article id="{section_id}" class="shirt-section"{collectible_attr}{player_attr} itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="{esc(title)}">
+            <meta itemprop="description" content="{esc(shirt_description(row))}">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="{esc(article_keywords)}">
+            <h3>{esc(title_with_size)}</h3>
             <div class="photo-row">
-        """
-
-        # First photo
-        if image1:
-            html_content += f"""
-                <div class="photo">
-                    <img src="{image1}" alt="{shirt_team} {shirt_season} {shirt_type} shirt" loading="lazy">
-                </div>
-            """
-
-        # Second photo
-        if image2:
-            html_content += f"""
-                <div class="photo">
-                    <img src="{image2}" alt="{shirt_team} {shirt_season} {shirt_type} shirt" loading="lazy">
-                </div>
-            """
-
-        # Third photo
-        if image3:
-            html_content += f"""
-                <div class="photo">
-                    <img src="{image3}" alt="{shirt_team} {shirt_season} {shirt_type} shirt" loading="lazy">
-                </div>
-            """
-        
-        html_content += "</div>"  # close .photo-row
-
-        # Display player information (if provided)
-        if shirt_player and shirt_number.strip():
-            html_content += f"""
-            <div class="player-info">Player: {shirt_player} - Number: {shirt_number}</div>
-            """
-
-        if shirt_extra:
-            html_content += f"""
-            <div class="collectible-info">Status: {shirt_extra}</div>
-            """
-
-        # Close the shirt section
-        html_content += """
-        </div>
-        """
-        
-        # Increment the counter
-        shirt_counter += 1
-
-    # Close the HTML content
-    html_content += """
-            </section>
-        </main>
-    </body>
-    </html>
     """
-    
-    # Write the HTML to a file
-    output_path = base_dir / 'shirts.html'
-    with open(output_path, 'w', encoding='utf-8') as htmlfile:
-        htmlfile.write(html_content)
+
+    for image_index, image in enumerate(images, start=1):
+        alt_parts = [shirt_team, shirt_season, shirt_type, "shirt"]
+        if shirt_player:
+            alt_parts.append(f"worn by or printed for {shirt_player}")
+        if shirt_number:
+            alt_parts.append(f"number {shirt_number}")
+        if shirt_extra:
+            alt_parts.append(shirt_extra)
+        alt_text = " ".join(alt_parts)
+        html_content += f"""
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="{esc(image)}" alt="{esc(alt_text)}" title="{esc(title)} photo {image_index}" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="{esc(alt_text)}">
+                </figure>
+        """
+
+    html_content += "\n            </div>"
+
+    if shirt_player or shirt_number:
+        if shirt_player and shirt_number:
+            player_text = f"Player: {shirt_player} - Number: {shirt_number}"
+        elif shirt_player:
+            player_text = f"Player: {shirt_player}"
+        else:
+            player_text = f"Number: {shirt_number}"
+        html_content += f"""
+            <div class="player-info">{esc(player_text)}</div>
+        """
+
+    detail_items = [
+        ("Season", shirt_season),
+        ("Type", shirt_type),
+        ("Size", shirt_size),
+    ]
+    if shirt_player:
+        detail_items.append(("Player", shirt_player))
+    if shirt_number:
+        detail_items.append(("Number", shirt_number))
+    if shirt_extra:
+        detail_items.append(("Status", shirt_extra))
+    if shirt_signatures:
+        detail_items.append(("Signatures", shirt_signatures))
+
+    if shirt_extra:
+        html_content += f"""
+            <div class="collectible-info">Status: {esc(shirt_extra)}</div>
+        """
+
+    html_content += "\n            <dl class=\"shirt-metadata\" aria-label=\"Shirt metadata\">"
+    for label, value in detail_items:
+        html_content += f"<dt>{esc(label)}</dt><dd>{esc(value)}</dd>"
+    html_content += "</dl>"
+
+    html_content += """
+        </article>
+    """
+    shirt_counter += 1
+
+html_content += """
+        </section>
+    </main>
+</body>
+</html>
+"""
+
+html_content = "\n".join(line.rstrip() for line in html_content.splitlines()).lstrip() + "\n"
+
+with open(output_path, "w", encoding="utf-8") as htmlfile:
+    htmlfile.write(html_content)
 
 print("HTML file has been generated successfully.")

--- a/shirts.html
+++ b/shirts.html
@@ -1,2487 +1,10139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor</title>
 
-        <title>Club Brugge Shirt Collection – Matteo De Moor</title>
+    <meta name="description" content="Browse Matteo De Moor&#x27;s searchable Club Brugge football shirt collection: 135 shirts with photos, seasons, sizes, shirt numbers, matchworn and signed shirts, including players such as Abakar Sylla, Ardon Jashari, Arnaut Danjuma, Bjorn Meijer, Bojan Jorgačević, Brandon Mechele, Brian Priske, Carl Hoefkens, Casper Nielsen, Charles De Ketelaere, Chemsdine Talbi, Christos Tzolis, Clinton Mata, Colin Coosemans, Davy De Fauw, Dion Cools, Dorin Rotariu, Eduard sobol." />
+    <meta name="keywords" content="Club Brugge shirts, Club Brugge shirt collection, Club Brugge matchworn shirts, Club Brugge signed shirts, football shirt collection, Abakar Sylla, Ardon Jashari, Arnaut Danjuma, Bjorn Meijer, Bojan Jorgačević, Brandon Mechele, Brian Priske, Carl Hoefkens, Casper Nielsen, Charles De Ketelaere, Chemsdine Talbi, Christos Tzolis, Clinton Mata, Colin Coosemans, Davy De Fauw, Dion Cools, Dorin Rotariu, Eduard sobol, Emmanuel Dennis Bonaventure, Ferran Jutglà Blanch, François Sterchele, Gert Verheyen, Hans Vanaken, Igor Thiago, Ivan Perišić, Jelle Vossen, Jeroen Simaeys, Joel Ordóñez, Jorne Spileers, Joseph Akpala, José Izquierdo, Kamal Sowah, Karel Geraerts, Krépin Diatta, Loïs Openda, Ludovic Butelle, Marvelous Nakamba, Mats Rits, Nicolás Castillo, Nicolò Tresoldi, Nikola Storm, Nordin Jackers, Philip Zinckernagel, Raphael Onyedika, Romeo Vermant, Ruud Vormer, Simon Deli, Simon Mignolet, Sofyan Amrabat, Stefano Denswil, Stijn Stijnen, Tajon Buchanan, Timmy Simons, Tom De Sutter, Vadis Odjidja-Ofoe, Waldemar Sobota, Wesley Moraes, Wesley Sonck, 1972-1973, 1987-1988, 1993-1994, 1996-1997, 1997-1998, 1998-1999, 1999-2000, 2000-2002, 2002-2003, 2002-2004, 2003-2004, 2004-2005, 2004-2006, 2005-2007, 2006-2007, 2007-2008, 2008-2009, 2009-2010, 2010-2011, 2011-2012, 2012-2013, 2013-2014, 2014-2015, 2015-2016, 2016-2017, 2017-2018, 2018-2019, 2019-2020, 2020-2021, 2021-2022, 2022-2023, 2023-2024, 2024-2025, 2025-2026, Away, Away Youth, Fourth, GK 1, GK 2, GK 3, GK 4, Home, Home Youth, Third, Copa, Framed, Matchworn, Retro, Signed" />
+    <meta name="author" content="Matteo De Moor" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 
-        <meta name="description" content="Browse Matteo De Moor’s Club Brugge football shirt collection with photos, seasons, sizes, players, matchworn shirts, and signed shirts." />
+    <link rel="canonical" href="https://matteodemoor.github.io/shirts.html" />
 
-        <meta name="robots" content="index, follow" />
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Matteo De Moor" />
+    <meta property="og:title" content="Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor" />
+    <meta property="og:description" content="A searchable personal archive of Club Brugge football shirts with photos, seasons, shirt numbers, player names, matchworn shirts and signed shirts." />
+    <meta property="og:image" content="https://matteodemoor.github.io/shirtImages/Shirt133.1.jpg" />
+    <meta property="og:image:alt" content="Club Brugge football shirt from Matteo De Moor's collection" />
+    <meta property="og:url" content="https://matteodemoor.github.io/shirts.html" />
+    <meta property="og:locale" content="en_US" />
 
-        <link rel="canonical" href="https://matteodemoor.github.io/shirts.html" />
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Club Brugge Shirt Collection, Players & Matchworn Shirts – Matteo De Moor" />
+    <meta name="twitter:description" content="A searchable personal archive of Club Brugge football shirts with photos, seasons, shirt numbers, player names, matchworn shirts and signed shirts." />
+    <meta name="twitter:image" content="https://matteodemoor.github.io/shirtImages/Shirt133.1.jpg" />
+    <meta name="twitter:image:alt" content="Club Brugge football shirt from Matteo De Moor's collection" />
 
-        <!-- Open Graph -->
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
-        <meta property="og:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
-        <meta property="og:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
-        <meta property="og:url" content="https://matteodemoor.github.io/shirts.html" />
+    <link rel="stylesheet" href="css/style2.css">
+    <link rel="stylesheet" href="css/style.css">
 
-        <!-- Twitter -->
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Club Brugge Shirt Collection – Matteo De Moor" />
-        <meta name="twitter:description" content="A personal archive of Club Brugge football shirts, including seasons, players, sizes, matchworn shirts, and signed shirts." />
-        <meta name="twitter:image" content="https://matteodemoor.github.io/images/Matteo.jpg" />
+    <link rel="icon" href="./images/ai2.png" type="image/x-icon">
 
-        <link rel="stylesheet" href="css/style2.css">
-        <link rel="stylesheet" href="css/style.css">
+    <script src="js/main.js" defer></script>
+    <script src="js/shirts.js" defer></script>
 
-        <link rel="icon" href="./images/ai2.png" type="image/x-icon">
-
-        <script src="js/main.js" defer></script>
-        <script src="js/shirts.js" defer></script>
-
-        <script type="application/ld+json">
-        {
+    <script type="application/ld+json">
+{
         "@context": "https://schema.org",
         "@graph": [
-            {
-            "@type": "CollectionPage",
-            "@id": "https://matteodemoor.github.io/shirts.html#collection",
-            "url": "https://matteodemoor.github.io/shirts.html",
-            "name": "Club Brugge Shirt Collection – Matteo De Moor",
-            "description": "A personal archive of Club Brugge football shirts with photos, seasons, sizes, players, matchworn shirts, and signed shirts.",
-            "about": [
-                "Club Brugge",
-                "Football shirts",
-                "Matchworn shirts",
-                "Signed shirts"
-            ],
-            "inLanguage": "en"
-            }
+                {
+                        "@type": "CollectionPage",
+                        "@id": "https://matteodemoor.github.io/shirts.html#collection",
+                        "url": "https://matteodemoor.github.io/shirts.html",
+                        "name": "Club Brugge Shirt Collection – Matteo De Moor",
+                        "headline": "Club Brugge football shirt collection with players, seasons and matchworn shirts",
+                        "description": "A personal searchable archive of Club Brugge football shirts with photos, seasons, sizes, player names, shirt numbers, matchworn shirts and signed shirts.",
+                        "isPartOf": {
+                                "@id": "https://matteodemoor.github.io/#website"
+                        },
+                        "publisher": {
+                                "@id": "https://matteodemoor.github.io/#person"
+                        },
+                        "about": [
+                                {
+                                        "@type": "SportsTeam",
+                                        "name": "Club Brugge",
+                                        "sameAs": "https://www.clubbrugge.be/"
+                                },
+                                "Club Brugge shirts",
+                                "Football shirts",
+                                "Matchworn football shirts",
+                                "Signed football shirts",
+                                "Abakar Sylla",
+                                "Ardon Jashari",
+                                "Arnaut Danjuma",
+                                "Bjorn Meijer",
+                                "Bojan Jorgačević",
+                                "Brandon Mechele",
+                                "Brian Priske",
+                                "Carl Hoefkens",
+                                "Casper Nielsen",
+                                "Charles De Ketelaere",
+                                "Chemsdine Talbi",
+                                "Christos Tzolis",
+                                "Clinton Mata",
+                                "Colin Coosemans",
+                                "Davy De Fauw",
+                                "Dion Cools",
+                                "Dorin Rotariu",
+                                "Eduard sobol",
+                                "Emmanuel Dennis Bonaventure",
+                                "Ferran Jutglà Blanch",
+                                "François Sterchele",
+                                "Gert Verheyen",
+                                "Hans Vanaken",
+                                "Igor Thiago",
+                                "Ivan Perišić"
+                        ],
+                        "keywords": [
+                                "Club Brugge shirt collection",
+                                "Club Brugge football shirts",
+                                "Club Brugge matchworn shirt",
+                                "Club Brugge signed shirt",
+                                "Abakar Sylla",
+                                "Ardon Jashari",
+                                "Arnaut Danjuma",
+                                "Bjorn Meijer",
+                                "Bojan Jorgačević",
+                                "Brandon Mechele",
+                                "Brian Priske",
+                                "Carl Hoefkens",
+                                "Casper Nielsen",
+                                "Charles De Ketelaere",
+                                "Chemsdine Talbi",
+                                "Christos Tzolis",
+                                "Clinton Mata",
+                                "Colin Coosemans",
+                                "Davy De Fauw",
+                                "Dion Cools",
+                                "Dorin Rotariu",
+                                "Eduard sobol",
+                                "Emmanuel Dennis Bonaventure",
+                                "Ferran Jutglà Blanch",
+                                "François Sterchele",
+                                "Gert Verheyen",
+                                "Hans Vanaken",
+                                "Igor Thiago",
+                                "Ivan Perišić",
+                                "Jelle Vossen",
+                                "Jeroen Simaeys",
+                                "Joel Ordóñez",
+                                "Jorne Spileers",
+                                "Joseph Akpala",
+                                "José Izquierdo",
+                                "Kamal Sowah",
+                                "Karel Geraerts",
+                                "Krépin Diatta",
+                                "Loïs Openda",
+                                "Ludovic Butelle",
+                                "Marvelous Nakamba",
+                                "Mats Rits",
+                                "Nicolás Castillo",
+                                "Nicolò Tresoldi",
+                                "Nikola Storm",
+                                "Nordin Jackers",
+                                "Philip Zinckernagel",
+                                "Raphael Onyedika",
+                                "Romeo Vermant",
+                                "Ruud Vormer",
+                                "Simon Deli",
+                                "Simon Mignolet",
+                                "Sofyan Amrabat",
+                                "Stefano Denswil",
+                                "Stijn Stijnen",
+                                "Tajon Buchanan",
+                                "Timmy Simons",
+                                "Tom De Sutter",
+                                "Vadis Odjidja-Ofoe",
+                                "Waldemar Sobota",
+                                "Wesley Moraes",
+                                "Wesley Sonck",
+                                "1972-1973",
+                                "1987-1988",
+                                "1993-1994",
+                                "1996-1997",
+                                "1997-1998",
+                                "1998-1999",
+                                "1999-2000",
+                                "2000-2002",
+                                "2002-2003",
+                                "2002-2004",
+                                "2003-2004",
+                                "2004-2005",
+                                "2004-2006",
+                                "2005-2007",
+                                "2006-2007",
+                                "2007-2008",
+                                "2008-2009",
+                                "2009-2010",
+                                "2010-2011",
+                                "2011-2012",
+                                "2012-2013",
+                                "2013-2014",
+                                "2014-2015",
+                                "2015-2016",
+                                "2016-2017",
+                                "2017-2018",
+                                "2018-2019",
+                                "2019-2020",
+                                "2020-2021",
+                                "2021-2022",
+                                "2022-2023",
+                                "2023-2024",
+                                "2024-2025",
+                                "2025-2026",
+                                "Away",
+                                "Away Youth",
+                                "Fourth",
+                                "GK 1",
+                                "GK 2",
+                                "GK 3",
+                                "GK 4",
+                                "Home",
+                                "Home Youth",
+                                "Third"
+                        ],
+                        "primaryImageOfPage": {
+                                "@type": "ImageObject",
+                                "url": "https://matteodemoor.github.io/shirtImages/Shirt133.1.jpg"
+                        },
+                        "inLanguage": "en"
+                },
+                {
+                        "@type": "BreadcrumbList",
+                        "@id": "https://matteodemoor.github.io/shirts.html#breadcrumb",
+                        "itemListElement": [
+                                {
+                                        "@type": "ListItem",
+                                        "position": 1,
+                                        "name": "Home",
+                                        "item": "https://matteodemoor.github.io/"
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 2,
+                                        "name": "Shirt Collection",
+                                        "item": "https://matteodemoor.github.io/shirts.html"
+                                }
+                        ]
+                },
+                {
+                        "@type": "ItemList",
+                        "@id": "https://matteodemoor.github.io/shirts.html#shirt-list",
+                        "name": "Club Brugge shirts by Matteo De Moor",
+                        "numberOfItems": 135,
+                        "itemListOrder": "https://schema.org/ItemListOrderDescending",
+                        "itemListElement": [
+                                {
+                                        "@type": "ListItem",
+                                        "position": 1,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-135",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-135",
+                                                "name": "Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15",
+                                                "description": "Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15, Size XL, Matchworn, signed by Raphael Onyedika.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt133.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt133.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt133.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "15"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Raphael Onyedika"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Raphael Onyedika"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 2,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-134",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-134",
+                                                "name": "Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14",
+                                                "description": "Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14, Size L, Matchworn, signed by Bjorn Meijer.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt121.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt121.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt121.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "14"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Bjorn Meijer"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Bjorn Meijer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 3,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-133",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-133",
+                                                "name": "Club Brugge 2025-2026 Away shirt - Christos Tzolis #8",
+                                                "description": "Club Brugge 2025-2026 Away shirt - Christos Tzolis #8, Size L, Signed, signed by Christos Tzolis.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt134.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt134.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "8"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Christos Tzolis"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Christos Tzolis"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 4,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-132",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-132",
+                                                "name": "Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7",
+                                                "description": "Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7, Size XL, Signed, signed by Nicolò Tresoldi.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt14.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt14.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "7"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Nicolò Tresoldi"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Nicolò Tresoldi"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 5,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-131",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-131",
+                                                "name": "Club Brugge 2025-2026 Third shirt - Romeo Vermant #11",
+                                                "description": "Club Brugge 2025-2026 Third shirt - Romeo Vermant #11, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt132.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt132.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "11"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Romeo Vermant"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 6,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-130",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-130",
+                                                "name": "Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29",
+                                                "description": "Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29, Size L, Matchworn, signed by Nordin Jackers.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt122.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt122.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt122.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2025-2026"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "29"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Nordin Jackers"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Nordin Jackers"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 7,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-129",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-129",
+                                                "name": "Club Brugge 2024-2025 Home shirt - Christos Tzolis #8",
+                                                "description": "Club Brugge 2024-2025 Home shirt - Christos Tzolis #8, Size 2XL, Signed, signed by Christos Tzolis.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt47.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt47.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "8"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Christos Tzolis"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Christos Tzolis"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 8,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-128",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-128",
+                                                "name": "Club Brugge 2024-2025 Home shirt",
+                                                "description": "Club Brugge 2024-2025 Home shirt, Size M, Signed, signed by Squad signed.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt69.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt69.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Squad signed"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 9,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-127",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-127",
+                                                "name": "Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68",
+                                                "description": "Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68, Size M, Matchworn, signed by Chemsdine Talbi.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt76.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt76.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt76.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "68"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Chemsdine Talbi"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Chemsdine Talbi"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 10,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-126",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-126",
+                                                "name": "Club Brugge 2024-2025 Home shirt - Brandon Mechele #44",
+                                                "description": "Club Brugge 2024-2025 Home shirt - Brandon Mechele #44, Size S, Signed, signed by Brandon Mechele.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt100.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt100.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "S"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "44"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Brandon Mechele"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Brandon Mechele"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 11,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-125",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-125",
+                                                "name": "Club Brugge 2024-2025 Away shirt - Hans Vanaken #20",
+                                                "description": "Club Brugge 2024-2025 Away shirt - Hans Vanaken #20, Size XL, Signed, signed by Hans Vanaken.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt5.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt5.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt5.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "20"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Hans Vanaken"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Hans Vanaken"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 12,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-124",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-124",
+                                                "name": "Club Brugge 2024-2025 Away shirt - Ardon Jashari #30",
+                                                "description": "Club Brugge 2024-2025 Away shirt - Ardon Jashari #30, Size XL, Signed, signed by Ardon Jashari.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt101.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt101.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt101.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "30"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Ardon Jashari"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ardon Jashari"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 13,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-123",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-123",
+                                                "name": "Club Brugge 2024-2025 Third shirt - Christos Tzolis #8",
+                                                "description": "Club Brugge 2024-2025 Third shirt - Christos Tzolis #8, Size XL, Signed, signed by Christos Tzolis.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt66.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt66.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "8"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Christos Tzolis"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Christos Tzolis"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 14,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-122",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-122",
+                                                "name": "Club Brugge 2024-2025 Third shirt",
+                                                "description": "Club Brugge 2024-2025 Third shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt98.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt98.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 15,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-121",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-121",
+                                                "name": "Club Brugge 2024-2025 GK 2 shirt",
+                                                "description": "Club Brugge 2024-2025 GK 2 shirt, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt123.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt123.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 16,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-120",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-120",
+                                                "name": "Club Brugge 2024-2025 GK 3 shirt",
+                                                "description": "Club Brugge 2024-2025 GK 3 shirt, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt124.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt124.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2024-2025"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 3"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 17,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-119",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-119",
+                                                "name": "Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77",
+                                                "description": "Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77, Size M, Matchworn, signed by Philip Zinckernagel.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt77.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt77.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt77.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "77"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Philip Zinckernagel"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Philip Zinckernagel"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 18,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-118",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-118",
+                                                "name": "Club Brugge 2023-2024 Home shirt - Hans Vanaken #20",
+                                                "description": "Club Brugge 2023-2024 Home shirt - Hans Vanaken #20, Size 2XL, Signed, signed by Hans Vanaken.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt43.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt43.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "20"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Hans Vanaken"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Hans Vanaken"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 19,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-117",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-117",
+                                                "name": "Club Brugge 2023-2024 Home shirt - Casper Nielsen #27",
+                                                "description": "Club Brugge 2023-2024 Home shirt - Casper Nielsen #27, Size M, Signed, signed by Casper Nielsen.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt102.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt102.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "27"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Casper Nielsen"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Casper Nielsen"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 20,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-116",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-116",
+                                                "name": "Club Brugge 2023-2024 Home shirt - Igor Thiago #99",
+                                                "description": "Club Brugge 2023-2024 Home shirt - Igor Thiago #99, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt111.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt111.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "99"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Igor Thiago"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 21,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-115",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-115",
+                                                "name": "Club Brugge 2023-2024 Away shirt - Brandon Mechele #44",
+                                                "description": "Club Brugge 2023-2024 Away shirt - Brandon Mechele #44, Size XL, Signed, signed by Brandon Mechele.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt61.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt61.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "44"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Brandon Mechele"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Brandon Mechele"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 22,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-114",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-114",
+                                                "name": "Club Brugge 2023-2024 Third shirt",
+                                                "description": "Club Brugge 2023-2024 Third shirt, Size XL, Signed, signed by Vetlesen, Skoras, Hayen, Seys, Mignolet, De Corte, Onyedika, Nielsen, De Cuyper, Meijer, Et Taïbi, Nilsson, Nusa, Talbi, Spileers, Jackers, Vermant, Boyata, Mechele, Tzolis, Zinckernagel.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt65.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt65.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Vetlesen, Skoras, Hayen, Seys, Mignolet, De Corte, Onyedika, Nielsen, De Cuyper, Meijer, Et Taïbi, Nilsson, Nusa, Talbi, Spileers, Jackers, Vermant, Boyata, Mechele, Tzolis, Zinckernagel"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 23,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-113",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-113",
+                                                "name": "Club Brugge 2023-2024 Fourth shirt",
+                                                "description": "Club Brugge 2023-2024 Fourth shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt78.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt78.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Fourth"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 24,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-112",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-112",
+                                                "name": "Club Brugge 2023-2024 GK 3 shirt",
+                                                "description": "Club Brugge 2023-2024 GK 3 shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt68.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt68.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2023-2024"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 3"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 25,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-111",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-111",
+                                                "name": "Club Brugge 2022-2023 Home shirt - Mats Rits #26",
+                                                "description": "Club Brugge 2022-2023 Home shirt - Mats Rits #26, Size XL, Signed, signed by Squad signed.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt64.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt64.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt64.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "26"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Squad signed"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Mats Rits"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 26,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-110",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-110",
+                                                "name": "Club Brugge 2022-2023 Home shirt - Jorne Spileers #27",
+                                                "description": "Club Brugge 2022-2023 Home shirt - Jorne Spileers #27, Size L, Signed, signed by Spileers.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt79.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt79.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt79.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "27"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Spileers"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Jorne Spileers"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 27,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-109",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-109",
+                                                "name": "Club Brugge 2022-2023 Away shirt - Abakar Sylla #94",
+                                                "description": "Club Brugge 2022-2023 Away shirt - Abakar Sylla #94, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt80.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt80.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "94"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Abakar Sylla"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 28,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-108",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-108",
+                                                "name": "Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4",
+                                                "description": "Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4, Size L, Signed, signed by Joel Ordóñez.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt63.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt63.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt63.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "4"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Joel Ordóñez"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Joel Ordóñez"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 29,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-107",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-107",
+                                                "name": "Club Brugge 2022-2023 Third shirt - Kamal Sowah #19",
+                                                "description": "Club Brugge 2022-2023 Third shirt - Kamal Sowah #19, Size M, Matchworn, signed by Kamal Sowah.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt125.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt125.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt125.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "19"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Kamal Sowah"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Kamal Sowah"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 30,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-106",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-106",
+                                                "name": "Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9",
+                                                "description": "Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9, Size XL, Signed, signed by Ferran Jutglà Blanch.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt81.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt81.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "9"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Ferran Jutglà Blanch"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ferran Jutglà Blanch"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 31,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-105",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-105",
+                                                "name": "Club Brugge 2022-2023 Third shirt - Casper Nielsen #27",
+                                                "description": "Club Brugge 2022-2023 Third shirt - Casper Nielsen #27, Size L, Signed, signed by Casper Nielsen.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt99.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt99.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "27"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Casper Nielsen"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Casper Nielsen"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 32,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-104",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-104",
+                                                "name": "Club Brugge 2022-2023 GK 1 shirt",
+                                                "description": "Club Brugge 2022-2023 GK 1 shirt, Size 2XL, Signed, signed by Mignolet.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt60.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt60.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Mignolet"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 33,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-103",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-103",
+                                                "name": "Club Brugge 2022-2023 GK 2 shirt",
+                                                "description": "Club Brugge 2022-2023 GK 2 shirt, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt59.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt59.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2022-2023"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 34,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-102",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-102",
+                                                "name": "Club Brugge 2021-2022 Home shirt",
+                                                "description": "Club Brugge 2021-2022 Home shirt, Size M, Signed, signed by De Ketelaere, Rits, Hoefkens, Jutgla, Skov Olsen, Sowah, Audoor, Meijer, Vanaken, Vormer, Sylla, Nusa, Mbamba, Shinton, Okereke, Nsoki, Balanta, Lammens, Izquierdo, Mata, Buchanan, Mechele, Lang, Sobol, Dost, Schreuder, Mignolet, Ricca, Sandra.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt58.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt58.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "De Ketelaere, Rits, Hoefkens, Jutgla, Skov Olsen, Sowah, Audoor, Meijer, Vanaken, Vormer, Sylla, Nusa, Mbamba, Shinton, Okereke, Nsoki, Balanta, Lammens, Izquierdo, Mata, Buchanan, Mechele, Lang, Sobol, Dost, Schreuder, Mignolet, Ricca, Sandra"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 35,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-101",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-101",
+                                                "name": "Club Brugge 2021-2022 Home shirt - Hans Vanaken #20",
+                                                "description": "Club Brugge 2021-2022 Home shirt - Hans Vanaken #20, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt48.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt48.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "20"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Hans Vanaken"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 36,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-100",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-100",
+                                                "name": "Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17",
+                                                "description": "Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt56.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt56.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "17"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Tajon Buchanan"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 37,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-99",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-99",
+                                                "name": "Club Brugge 2021-2022 Away shirt",
+                                                "description": "Club Brugge 2021-2022 Away shirt, Size 2XL, Signed, signed by Nusa, Bursik, Jutgla, Thiago, Mechele, Spileers, De Cuyper, Barbera, Meijer, Jackers, Homma, Vetlesen, Shinton, Mignolet, Talbi, Onyedika, Balanta, Ordonez.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt54.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt54.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Nusa, Bursik, Jutgla, Thiago, Mechele, Spileers, De Cuyper, Barbera, Meijer, Jackers, Homma, Vetlesen, Shinton, Mignolet, Talbi, Onyedika, Balanta, Ordonez"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 38,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-98",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-98",
+                                                "name": "Club Brugge 2021-2022 Away shirt - Eduard sobol #2",
+                                                "description": "Club Brugge 2021-2022 Away shirt - Eduard sobol #2, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt126.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt126.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "2"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Eduard sobol"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 39,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-97",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-97",
+                                                "name": "Club Brugge 2021-2022 Away Youth shirt - #15",
+                                                "description": "Club Brugge 2021-2022 Away Youth shirt - #15, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt18.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt18.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt18.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away Youth"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "15"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 40,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-96",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-96",
+                                                "name": "Club Brugge 2021-2022 Third shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2021-2022 Third shirt - Ruud Vormer #25, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt52.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt52.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 41,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-95",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-95",
+                                                "name": "Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22",
+                                                "description": "Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22, Size XL, Signed, signed by Simon Mignolet.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt39.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt39.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "22"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Simon Mignolet"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Simon Mignolet"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 42,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-94",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-94",
+                                                "name": "Club Brugge 2021-2022 GK 2 shirt",
+                                                "description": "Club Brugge 2021-2022 GK 2 shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt92.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt92.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2021-2022"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 43,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-93",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-93",
+                                                "name": "Club Brugge 2020-2021 Home shirt",
+                                                "description": "Club Brugge 2020-2021 Home shirt, Size S, Signed, signed by Charles De Ketelaere.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt50.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt50.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt50.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "S"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Charles De Ketelaere"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 44,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-92",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-92",
+                                                "name": "Club Brugge 2020-2021 Home Youth shirt",
+                                                "description": "Club Brugge 2020-2021 Home Youth shirt, Size M, Signed, signed by Squad signed.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt119.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt119.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home Youth"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Squad signed"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 45,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-91",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-91",
+                                                "name": "Club Brugge 2020-2021 Home shirt - Clinton Mata #77",
+                                                "description": "Club Brugge 2020-2021 Home shirt - Clinton Mata #77, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt110.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt110.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "77"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Clinton Mata"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 46,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-90",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-90",
+                                                "name": "Club Brugge 2020-2021 Home shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2020-2021 Home shirt - Ruud Vormer #25, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt109.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt109.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 47,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-89",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-89",
+                                                "name": "Club Brugge 2020-2021 Away shirt",
+                                                "description": "Club Brugge 2020-2021 Away shirt, Size M, Signed, signed by Lambert, Lang, De ketelaere, Mignolet, Odoi, Skov Olsen, Lammens, Mata, Buchanan, Balanta, Sobol, Otasowie.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt49.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt49.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Lambert, Lang, De ketelaere, Mignolet, Odoi, Skov Olsen, Lammens, Mata, Buchanan, Balanta, Sobol, Otasowie"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 48,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-88",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-88",
+                                                "name": "Club Brugge 2020-2021 Away shirt - Simon Mignolet #88",
+                                                "description": "Club Brugge 2020-2021 Away shirt - Simon Mignolet #88, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt117.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt117.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "88"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Simon Mignolet"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 49,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-87",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-87",
+                                                "name": "Club Brugge 2020-2021 Away shirt - Stefano Denswil #24",
+                                                "description": "Club Brugge 2020-2021 Away shirt - Stefano Denswil #24, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt83.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt83.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "24"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Stefano Denswil"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 50,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-86",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-86",
+                                                "name": "Club Brugge 2020-2021 Third shirt",
+                                                "description": "Club Brugge 2020-2021 Third shirt, Size 2XL, Signed, signed by Vanaken, Vetlesen, Vermant, Nillsson, Siquet, De Cuyper, Hayen, Talbi, Romero, Onyedika, Odoi, Meijer, Seys, Ordonez, Audoor, Jashari.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt57.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt57.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt57.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Vanaken, Vetlesen, Vermant, Nillsson, Siquet, De Cuyper, Hayen, Talbi, Romero, Onyedika, Odoi, Meijer, Seys, Ordonez, Audoor, Jashari"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 51,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-85",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-85",
+                                                "name": "Club Brugge 2020-2021 GK 1 shirt",
+                                                "description": "Club Brugge 2020-2021 GK 1 shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt46.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt46.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 52,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-84",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-84",
+                                                "name": "Club Brugge 2020-2021 GK 2 shirt",
+                                                "description": "Club Brugge 2020-2021 GK 2 shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt127.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt127.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2020-2021"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 53,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-83",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-83",
+                                                "name": "Club Brugge 2019-2020 Home shirt - Clinton Mata #77",
+                                                "description": "Club Brugge 2019-2020 Home shirt - Clinton Mata #77, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt116.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt116.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "77"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Clinton Mata"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 54,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-82",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-82",
+                                                "name": "Club Brugge 2019-2020 Home shirt - Eduard Sobol #2",
+                                                "description": "Club Brugge 2019-2020 Home shirt - Eduard Sobol #2, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt45.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt45.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt45.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "2"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Eduard Sobol"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 55,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-81",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-81",
+                                                "name": "Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90",
+                                                "description": "Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt84.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt84.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "90"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Charles De Ketelaere"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 56,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-80",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-80",
+                                                "name": "Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90",
+                                                "description": "Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt85.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt85.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "90"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Charles De Ketelaere"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 57,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-79",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-79",
+                                                "name": "Club Brugge 2019-2020 Third shirt - Simon Deli #17",
+                                                "description": "Club Brugge 2019-2020 Third shirt - Simon Deli #17, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt118.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt118.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "17"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Simon Deli"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 58,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-78",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-78",
+                                                "name": "Club Brugge 2019-2020 Third shirt",
+                                                "description": "Club Brugge 2019-2020 Third shirt, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt86.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt86.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2019-2020"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 59,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-77",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-77",
+                                                "name": "Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47",
+                                                "description": "Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47, Size M, Matchworn.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt108.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt108.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt108.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "47"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Arnaut Danjuma"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 60,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-76",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-76",
+                                                "name": "Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6",
+                                                "description": "Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt41.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt41.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "6"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Sofyan Amrabat"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 61,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-75",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-75",
+                                                "name": "Club Brugge 2018-2019 Away shirt - Jelle Vossen #9",
+                                                "description": "Club Brugge 2018-2019 Away shirt - Jelle Vossen #9, Size XL, signed by Jelle Vossen.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt40.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt40.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt40.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "9"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Jelle Vossen"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Jelle Vossen"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 62,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-74",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-74",
+                                                "name": "Club Brugge 2018-2019 Away shirt - Loïs Openda #80",
+                                                "description": "Club Brugge 2018-2019 Away shirt - Loïs Openda #80, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt87.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt87.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "80"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Loïs Openda"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 63,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-73",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-73",
+                                                "name": "Club Brugge 2018-2019 Away shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2018-2019 Away shirt - Ruud Vormer #25, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt1.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt1.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 64,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-72",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-72",
+                                                "name": "Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47",
+                                                "description": "Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47, Size 4XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt115.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt115.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "4XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "47"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Arnaut Danjuma"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 65,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-71",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-71",
+                                                "name": "Club Brugge 2018-2019 Third shirt - Krépin Diatta #11",
+                                                "description": "Club Brugge 2018-2019 Third shirt - Krépin Diatta #11, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt62.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt62.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "11"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Krépin Diatta"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 66,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-70",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-70",
+                                                "name": "Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42",
+                                                "description": "Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt55.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt55.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "42"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Emmanuel Dennis Bonaventure"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 67,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-69",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-69",
+                                                "name": "Club Brugge 2018-2019 Third shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2018-2019 Third shirt - Ruud Vormer #25, Size 2XL, Framed, signed by Ruud Vormer.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt38.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt38.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2018-2019"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Framed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Ruud Vormer"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 68,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-68",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-68",
+                                                "name": "Club Brugge 2017-2018 Home shirt - Wesley Moraes #7",
+                                                "description": "Club Brugge 2017-2018 Home shirt - Wesley Moraes #7, Size XL, Matchworn.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt107.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt107.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt107.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "7"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Wesley Moraes"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 69,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-67",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-67",
+                                                "name": "Club Brugge 2017-2018 Home shirt - Stefano Denswil #24",
+                                                "description": "Club Brugge 2017-2018 Home shirt - Stefano Denswil #24, Size L, Matchworn.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt106.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt106.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt106.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "24"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Matchworn"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Stefano Denswil"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 70,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-66",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-66",
+                                                "name": "Club Brugge 2017-2018 Home shirt - Hans Vanaken #20",
+                                                "description": "Club Brugge 2017-2018 Home shirt - Hans Vanaken #20, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt36.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt36.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "20"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Hans Vanaken"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 71,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-65",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-65",
+                                                "name": "Club Brugge 2017-2018 Home shirt - Timmy Simons #3",
+                                                "description": "Club Brugge 2017-2018 Home shirt - Timmy Simons #3, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt44.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt44.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "3"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Timmy Simons"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 72,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-64",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-64",
+                                                "name": "Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30",
+                                                "description": "Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30, Size XL, Signed, signed by Marvelous Nakamba.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt35.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt35.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "30"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Marvelous Nakamba"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Marvelous Nakamba"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 73,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-63",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-63",
+                                                "name": "Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42",
+                                                "description": "Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt34.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt34.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "42"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Emmanuel Dennis Bonaventure"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 74,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-62",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-62",
+                                                "name": "Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30",
+                                                "description": "Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30, Size XL, Signed, signed by Marvelous Nakamba.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt33.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt33.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "30"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Marvelous Nakamba"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Marvelous Nakamba"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 75,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-61",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-61",
+                                                "name": "Club Brugge 2017-2018 Fourth shirt",
+                                                "description": "Club Brugge 2017-2018 Fourth shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt31.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt31.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Fourth"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 76,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-60",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-60",
+                                                "name": "Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1",
+                                                "description": "Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt135.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt135.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "1"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ludovic Butelle"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 77,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-59",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-59",
+                                                "name": "Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1",
+                                                "description": "Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt112.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt112.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 3"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "1"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ludovic Butelle"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 78,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-58",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-58",
+                                                "name": "Club Brugge 2017-2018 GK 4 shirt",
+                                                "description": "Club Brugge 2017-2018 GK 4 shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt32.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt32.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2017-2018"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 4"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 79,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-57",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-57",
+                                                "name": "Club Brugge 2016-2017 Home shirt - José Izquierdo #11",
+                                                "description": "Club Brugge 2016-2017 Home shirt - José Izquierdo #11, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt30.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt30.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt30.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "11"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "José Izquierdo"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 80,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-56",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-56",
+                                                "name": "Club Brugge 2016-2017 Home shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2016-2017 Home shirt - Ruud Vormer #25, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt29.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt29.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 81,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-55",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-55",
+                                                "name": "Club Brugge 2016-2017 Home shirt - Timmy Simons #3",
+                                                "description": "Club Brugge 2016-2017 Home shirt - Timmy Simons #3, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt37.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt37.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "3"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Timmy Simons"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 82,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-54",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-54",
+                                                "name": "Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29",
+                                                "description": "Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt120.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt120.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "29"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Dorin Rotariu"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 83,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-53",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-53",
+                                                "name": "Club Brugge 2016-2017 Away shirt - Timmy Simons #3",
+                                                "description": "Club Brugge 2016-2017 Away shirt - Timmy Simons #3, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt23.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt23.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "3"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Timmy Simons"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 84,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-52",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-52",
+                                                "name": "Club Brugge 2016-2017 Third shirt - Ruud Vormer #25",
+                                                "description": "Club Brugge 2016-2017 Third shirt - Ruud Vormer #25, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt28.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt28.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "25"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ruud Vormer"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 85,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-51",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-51",
+                                                "name": "Club Brugge 2016-2017 GK 2 shirt",
+                                                "description": "Club Brugge 2016-2017 GK 2 shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt22.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt22.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2016-2017"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 86,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-50",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-50",
+                                                "name": "Club Brugge 2015-2016 Away shirt - Dion Cools #21",
+                                                "description": "Club Brugge 2015-2016 Away shirt - Dion Cools #21, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt21.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt21.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2015-2016"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "21"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Dion Cools"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 87,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-49",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-49",
+                                                "name": "Club Brugge 2015-2016 GK 1 shirt",
+                                                "description": "Club Brugge 2015-2016 GK 1 shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt113.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt113.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2015-2016"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 88,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-48",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-48",
+                                                "name": "Club Brugge 2014-2015 Home shirt - Nikola Storm #42",
+                                                "description": "Club Brugge 2014-2015 Home shirt - Nikola Storm #42, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt97.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt97.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2014-2015"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "42"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Nikola Storm"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 89,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-47",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-47",
+                                                "name": "Club Brugge 2014-2015 Home shirt - #12",
+                                                "description": "Club Brugge 2014-2015 Home shirt - #12, Size XL, Signed, signed by Squad signed.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt70.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt70.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt70.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2014-2015"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "12"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Squad signed"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 90,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-46",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-46",
+                                                "name": "Club Brugge 2014-2015 Home shirt - Davy De Fauw #2",
+                                                "description": "Club Brugge 2014-2015 Home shirt - Davy De Fauw #2, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt26.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt26.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2014-2015"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "2"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Davy De Fauw"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 91,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-45",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-45",
+                                                "name": "Club Brugge 2014-2015 Away shirt",
+                                                "description": "Club Brugge 2014-2015 Away shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt82.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt82.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2014-2015"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 92,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-44",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-44",
+                                                "name": "Club Brugge 2013-2014 Home shirt - Tom De Sutter #9",
+                                                "description": "Club Brugge 2013-2014 Home shirt - Tom De Sutter #9, Size L, Signed, signed by Tom De Sutter.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt25.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt25.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2013-2014"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "9"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Tom De Sutter"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Tom De Sutter"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 93,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-43",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-43",
+                                                "name": "Club Brugge 2013-2014 Home shirt - Tom De Sutter #9",
+                                                "description": "Club Brugge 2013-2014 Home shirt - Tom De Sutter #9, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt95.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt95.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2013-2014"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "9"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Tom De Sutter"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 94,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-42",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-42",
+                                                "name": "Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17",
+                                                "description": "Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt24.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt24.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2013-2014"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "17"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Waldemar Sobota"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 95,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-41",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-41",
+                                                "name": "Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30",
+                                                "description": "Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt94.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt94.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2013-2014"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "30"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Nicolás Castillo"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 96,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-40",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-40",
+                                                "name": "Club Brugge 2013-2014 Third shirt",
+                                                "description": "Club Brugge 2013-2014 Third shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt93.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt93.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2013-2014"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 97,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-39",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-39",
+                                                "name": "Club Brugge 2012-2013 Home shirt",
+                                                "description": "Club Brugge 2012-2013 Home shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt91.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt91.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2012-2013"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 98,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-38",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-38",
+                                                "name": "Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4",
+                                                "description": "Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt20.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt20.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt20.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2012-2013"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "4"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Carl Hoefkens"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 99,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-37",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-37",
+                                                "name": "Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39",
+                                                "description": "Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt19.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt19.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2012-2013"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "39"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Bojan Jorgačević"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 100,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-36",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-36",
+                                                "name": "Club Brugge 2011-2012 Home shirt",
+                                                "description": "Club Brugge 2011-2012 Home shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt128.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt128.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2011-2012"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 101,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-35",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-35",
+                                                "name": "Club Brugge 2011-2012 Away shirt",
+                                                "description": "Club Brugge 2011-2012 Away shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt4.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt4.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2011-2012"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 102,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-34",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-34",
+                                                "name": "Club Brugge 2010-2011 Home shirt - Joseph Akpala #15",
+                                                "description": "Club Brugge 2010-2011 Home shirt - Joseph Akpala #15, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt90.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt90.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2010-2011"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "15"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Joseph Akpala"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 103,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-33",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-33",
+                                                "name": "Club Brugge 2010-2011 Home shirt - Ivan Perišić #44",
+                                                "description": "Club Brugge 2010-2011 Home shirt - Ivan Perišić #44, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt17.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt17.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt17.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2010-2011"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "44"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Ivan Perišić"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 104,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-32",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-32",
+                                                "name": "Club Brugge 2010-2011 Away shirt",
+                                                "description": "Club Brugge 2010-2011 Away shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt16.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt16.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2010-2011"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 105,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-31",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-31",
+                                                "name": "Club Brugge 2010-2011 GK 1 shirt",
+                                                "description": "Club Brugge 2010-2011 GK 1 shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt103.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt103.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2010-2011"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 106,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-30",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-30",
+                                                "name": "Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1",
+                                                "description": "Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt129.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt129.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2010-2011"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "1"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Colin Coosemans"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 107,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-29",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-29",
+                                                "name": "Club Brugge 2009-2010 Home shirt",
+                                                "description": "Club Brugge 2009-2010 Home shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt15.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt15.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2009-2010"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 108,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-28",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-28",
+                                                "name": "Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32",
+                                                "description": "Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32, Size M, Signed, signed by Vadis Odjidja-Ofoe.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt130.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt130.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2009-2010"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "32"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Vadis Odjidja-Ofoe"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Vadis Odjidja-Ofoe"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 109,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-27",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-27",
+                                                "name": "Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1",
+                                                "description": "Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1, Size S.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt13.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt13.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2009-2010"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "S"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "1"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Stijn Stijnen"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 110,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-26",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-26",
+                                                "name": "Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14",
+                                                "description": "Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14, Size L, Signed, signed by Squad signed.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt75.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt75.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2008-2009"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "14"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Squad signed"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Jeroen Simaeys"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 111,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-25",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-25",
+                                                "name": "Club Brugge 2008-2009 Home shirt - Karel Geraerts #22",
+                                                "description": "Club Brugge 2008-2009 Home shirt - Karel Geraerts #22, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt104.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt104.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2008-2009"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "22"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Karel Geraerts"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 112,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-24",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-24",
+                                                "name": "Club Brugge 2008-2009 Away shirt",
+                                                "description": "Club Brugge 2008-2009 Away shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt12.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt12.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2008-2009"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 113,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-23",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-23",
+                                                "name": "Club Brugge 2008-2009 Third shirt",
+                                                "description": "Club Brugge 2008-2009 Third shirt, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt11.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt11.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2008-2009"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Third"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 114,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-22",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-22",
+                                                "name": "Club Brugge 2007-2008 Home shirt - Wesley Sonck #10",
+                                                "description": "Club Brugge 2007-2008 Home shirt - Wesley Sonck #10, Size 3XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt74.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt74.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2007-2008"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "3XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "10"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Wesley Sonck"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 115,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-21",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-21",
+                                                "name": "Club Brugge 2007-2008 Away shirt - François Sterchele #23",
+                                                "description": "Club Brugge 2007-2008 Away shirt - François Sterchele #23, Size S.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt10.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt10.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2007-2008"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "S"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "23"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "François Sterchele"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 116,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-20",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-20",
+                                                "name": "Club Brugge 2006-2007 Away shirt",
+                                                "description": "Club Brugge 2006-2007 Away shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt8.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt8.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2006-2007"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 117,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-19",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-19",
+                                                "name": "Club Brugge 2006-2007 GK 2 shirt - #23",
+                                                "description": "Club Brugge 2006-2007 GK 2 shirt - #23, Size L.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt51.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt51.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2006-2007"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 2"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "23"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 118,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-18",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-18",
+                                                "name": "Club Brugge 2005-2007 Home shirt - Brian Priske #24",
+                                                "description": "Club Brugge 2005-2007 Home shirt - Brian Priske #24, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt9.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt9.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2005-2007"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "24"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Brian Priske"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 119,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-17",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-17",
+                                                "name": "Club Brugge 2004-2006 Away shirt - Gert Verheyen #7",
+                                                "description": "Club Brugge 2004-2006 Away shirt - Gert Verheyen #7, Size 2XL, Signed, signed by Gert Verheyen.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt7.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt7.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt7.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2004-2006"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "7"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Signed"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Signatures",
+                                                                "value": "Gert Verheyen"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Gert Verheyen"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 120,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-16",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-16",
+                                                "name": "Club Brugge 2004-2005 GK 1 shirt",
+                                                "description": "Club Brugge 2004-2005 GK 1 shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt6.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt6.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2004-2005"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "GK 1"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 121,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-15",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-15",
+                                                "name": "Club Brugge 2003-2004 Away shirt",
+                                                "description": "Club Brugge 2003-2004 Away shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt42.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt42.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2003-2004"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 122,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-14",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-14",
+                                                "name": "Club Brugge 2002-2004 Home shirt",
+                                                "description": "Club Brugge 2002-2004 Home shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt89.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt89.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2002-2004"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 123,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-13",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-13",
+                                                "name": "Club Brugge 2002-2003 Away shirt - Timmy Simons #3",
+                                                "description": "Club Brugge 2002-2003 Away shirt - Timmy Simons #3, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt53.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt53.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2002-2003"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "3"
+                                                        }
+                                                ],
+                                                "about": {
+                                                        "@type": "Person",
+                                                        "name": "Timmy Simons"
+                                                }
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 124,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-12",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-12",
+                                                "name": "Club Brugge 2000-2002 Home shirt - #31",
+                                                "description": "Club Brugge 2000-2002 Home shirt - #31, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt67.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt67.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2000-2002"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "31"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 125,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-11",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-11",
+                                                "name": "Club Brugge 2000-2002 Home shirt",
+                                                "description": "Club Brugge 2000-2002 Home shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt88.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt88.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2000-2002"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 126,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-10",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-10",
+                                                "name": "Club Brugge 2000-2002 Away shirt",
+                                                "description": "Club Brugge 2000-2002 Away shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt73.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt73.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "2000-2002"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 127,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-9",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-9",
+                                                "name": "Club Brugge 1999-2000 Home shirt",
+                                                "description": "Club Brugge 1999-2000 Home shirt, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt3.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt3.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1999-2000"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 128,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-8",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-8",
+                                                "name": "Club Brugge 1998-1999 Home shirt",
+                                                "description": "Club Brugge 1998-1999 Home shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt72.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt72.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1998-1999"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 129,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-7",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-7",
+                                                "name": "Club Brugge 1998-1999 Away shirt",
+                                                "description": "Club Brugge 1998-1999 Away shirt, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt96.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt96.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt96.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1998-1999"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 130,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-6",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-6",
+                                                "name": "Club Brugge 1997-1998 Home shirt - #23",
+                                                "description": "Club Brugge 1997-1998 Home shirt - #23, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt2.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt2.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1997-1998"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "23"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 131,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-5",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-5",
+                                                "name": "Club Brugge 1996-1997 Home Youth shirt - #4",
+                                                "description": "Club Brugge 1996-1997 Home Youth shirt - #4, Size XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt71.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt71.1.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1996-1997"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home Youth"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Squad number",
+                                                                "value": "4"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 132,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-4",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-4",
+                                                "name": "Club Brugge 1996-1997 Away shirt",
+                                                "description": "Club Brugge 1996-1997 Away shirt, Size 2XL.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt27.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt27.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1996-1997"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Away"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "2XL"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 133,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-3",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-3",
+                                                "name": "Club Brugge 1993-1994 Home shirt",
+                                                "description": "Club Brugge 1993-1994 Home shirt, Size M.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt131.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt131.2.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt131.3.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1993-1994"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "M"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 134,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-2",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-2",
+                                                "name": "Club Brugge 1987-1988 Home shirt",
+                                                "description": "Club Brugge 1987-1988 Home shirt, Size L, Copa.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt114.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt114.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1987-1988"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "L"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Copa"
+                                                        }
+                                                ]
+                                        }
+                                },
+                                {
+                                        "@type": "ListItem",
+                                        "position": 135,
+                                        "url": "https://matteodemoor.github.io/shirts.html#shirt-1",
+                                        "item": {
+                                                "@type": "Product",
+                                                "@id": "https://matteodemoor.github.io/shirts.html#shirt-1",
+                                                "name": "Club Brugge 1972-1973 Home shirt",
+                                                "description": "Club Brugge 1972-1973 Home shirt, Size XL, Retro.",
+                                                "category": "Football shirt",
+                                                "brand": {
+                                                        "@type": "SportsTeam",
+                                                        "name": "Club Brugge",
+                                                        "sameAs": "https://www.clubbrugge.be/"
+                                                },
+                                                "image": [
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt105.1.jpg",
+                                                        "https://matteodemoor.github.io/shirtImages/Shirt105.2.jpg"
+                                                ],
+                                                "additionalProperty": [
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Season",
+                                                                "value": "1972-1973"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Shirt type",
+                                                                "value": "Home"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Size",
+                                                                "value": "XL"
+                                                        },
+                                                        {
+                                                                "@type": "PropertyValue",
+                                                                "name": "Collectible status",
+                                                                "value": "Retro"
+                                                        }
+                                                ]
+                                        }
+                                }
+                        ]
+                }
         ]
-        }
-        </script>
-    </head>
-    <body class="home-page collection-page">
-        <header class="top-bar command-nav">
-          <nav>
-            <a href="index.html">Homepage</a>
-            <a href="shirts.html">Shirt Collection</a>
-          </nav>
-        </header>
+}
+    </script>
+</head>
+<body class="home-page collection-page">
+    <header class="top-bar command-nav">
+      <nav>
+        <a href="index.html">Homepage</a>
+        <a href="shirts.html">Shirt Collection</a>
+      </nav>
+    </header>
 
-        <main>
-            <section class="collection-shell">
-                <div class="collection-intro">
-                    <span class="panel-kicker">Club Brugge archive</span>
-                    <h1>My personal shirt collection</h1>
-                    <p>Here you can find my unique Club Brugge shirts collection.</p>
-                </div>
-                <div class="filter-bar" aria-label="Filter shirts">
-                  <div class="filter-group">
-                    <label for="filter-season">Season</label>
-                    <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="filter-type">Type</label>
-                    <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
-                  </div>
-                <div class="filter-group">
-                    <label for="filter-size">Size</label>
-                    <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="filter-collectible">Collectible</label>
-                    <select id="filter-collectible" multiple size="5" aria-label="Filter by collectible status"></select>
-                  </div>
-                  <div class="filter-group filter-group--player">
-                    <label for="filter-player">Player</label>
-                    <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
-                  </div>
-                  <div class="filter-actions">
-                    <button id="filter-clear">Clear</button>
-                  </div>
-                </div>
-    
+    <main>
+        <section class="collection-shell" itemscope itemtype="https://schema.org/CollectionPage">
+            <div class="collection-intro">
+                <span class="panel-kicker">Club Brugge archive</span>
+                <h1 itemprop="name">My personal Club Brugge shirt collection</h1>
+                <p itemprop="description">Here you can find my unique, searchable Club Brugge shirts collection with player names, shirt numbers, seasons, sizes, matchworn shirts and signed shirts.</p>
+                <p class="collection-meta">This archive contains 135 Club Brugge shirts across 34 seasons and 58 named players, including Abakar Sylla, Ardon Jashari, Arnaut Danjuma, Bjorn Meijer, Bojan Jorgačević, Brandon Mechele, Brian Priske, Carl Hoefkens, Casper Nielsen, Charles De Ketelaere, Chemsdine Talbi, Christos Tzolis, Clinton Mata, Colin Coosemans, Davy De Fauw, Dion Cools, Dorin Rotariu, Eduard sobol.</p>
+            </div>
+            <div class="filter-bar" aria-label="Filter shirts">
+              <div class="filter-group">
+                <label for="filter-season">Season</label>
+                <select id="filter-season" multiple size="5" aria-label="Filter by season"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-type">Type</label>
+                <select id="filter-type" multiple size="5" aria-label="Filter by type"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-size">Size</label>
+                <select id="filter-size" multiple size="5" aria-label="Filter by size"></select>
+              </div>
+              <div class="filter-group">
+                <label for="filter-collectible">Collectible</label>
+                <select id="filter-collectible" multiple size="5" aria-label="Filter by collectible status"></select>
+              </div>
+              <div class="filter-group filter-group--player">
+                <label for="filter-player">Player</label>
+                <select id="filter-player" multiple size="5" aria-label="Filter by player"></select>
+              </div>
+              <div class="filter-actions">
+                <button id="filter-clear">Clear</button>
+              </div>
+            </div>
+
         <!-- Shirt 1 (ID: 135) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2025-2026 Home - Size: XL</h3>
+        <article id="shirt-135" class="shirt-section" data-collectible="matchworn" data-player="raphael onyedika" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15">
+            <meta itemprop="description" content="Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15, Size XL, Matchworn, signed by Raphael Onyedika.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, Home, Raphael Onyedika, 15, Matchworn">
+            <h3>Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt133.1.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt133.2.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt133.3.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt133.1.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn" title="Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt133.2.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn" title="Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt133.3.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn" title="Club Brugge 2025-2026 Home shirt - Raphael Onyedika #15 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Raphael Onyedika number 15 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Raphael Onyedika - Number: 15</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Raphael Onyedika</dd><dt>Number</dt><dd>15</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Raphael Onyedika</dd></dl>
+        </article>
+
         <!-- Shirt 2 (ID: 134) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2025-2026 Home - Size: L</h3>
+        <article id="shirt-134" class="shirt-section" data-collectible="matchworn" data-player="bjorn meijer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14">
+            <meta itemprop="description" content="Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14, Size L, Matchworn, signed by Bjorn Meijer.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, Home, Bjorn Meijer, 14, Matchworn">
+            <h3>Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt121.1.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt121.2.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt121.3.jpg" alt="Club Brugge 2025-2026 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt121.1.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn" title="Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt121.2.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn" title="Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt121.3.jpg" alt="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn" title="Club Brugge 2025-2026 Home shirt - Bjorn Meijer #14 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Home shirt worn by or printed for Bjorn Meijer number 14 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Bjorn Meijer - Number: 14</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Bjorn Meijer</dd><dt>Number</dt><dd>14</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Bjorn Meijer</dd></dl>
+        </article>
+
         <!-- Shirt 3 (ID: 133) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2025-2026 Away - Size: L</h3>
+        <article id="shirt-133" class="shirt-section" data-collectible="signed" data-player="christos tzolis" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 Away shirt - Christos Tzolis #8">
+            <meta itemprop="description" content="Club Brugge 2025-2026 Away shirt - Christos Tzolis #8, Size L, Signed, signed by Christos Tzolis.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, Away, Christos Tzolis, 8, Signed">
+            <h3>Club Brugge 2025-2026 Away shirt - Christos Tzolis #8 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt134.1.jpg" alt="Club Brugge 2025-2026 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt134.2.jpg" alt="Club Brugge 2025-2026 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt134.1.jpg" alt="Club Brugge 2025-2026 Away shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2025-2026 Away shirt - Christos Tzolis #8 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Away shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt134.2.jpg" alt="Club Brugge 2025-2026 Away shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2025-2026 Away shirt - Christos Tzolis #8 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Away shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Christos Tzolis - Number: 8</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Christos Tzolis</dd><dt>Number</dt><dd>8</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Christos Tzolis</dd></dl>
+        </article>
+
         <!-- Shirt 4 (ID: 132) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2025-2026 Third - Size: XL</h3>
+        <article id="shirt-132" class="shirt-section" data-collectible="signed" data-player="nicolò tresoldi" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7">
+            <meta itemprop="description" content="Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7, Size XL, Signed, signed by Nicolò Tresoldi.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, Third, Nicolò Tresoldi, 7, Signed">
+            <h3>Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt14.1.jpg" alt="Club Brugge 2025-2026 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt14.2.jpg" alt="Club Brugge 2025-2026 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt14.1.jpg" alt="Club Brugge 2025-2026 Third shirt worn by or printed for Nicolò Tresoldi number 7 Signed" title="Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Third shirt worn by or printed for Nicolò Tresoldi number 7 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt14.2.jpg" alt="Club Brugge 2025-2026 Third shirt worn by or printed for Nicolò Tresoldi number 7 Signed" title="Club Brugge 2025-2026 Third shirt - Nicolò Tresoldi #7 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Third shirt worn by or printed for Nicolò Tresoldi number 7 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Nicolò Tresoldi - Number: 7</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Nicolò Tresoldi</dd><dt>Number</dt><dd>7</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Nicolò Tresoldi</dd></dl>
+        </article>
+
         <!-- Shirt 5 (ID: 131) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2025-2026 Third - Size: M</h3>
+        <article id="shirt-131" class="shirt-section" data-player="romeo vermant" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 Third shirt - Romeo Vermant #11">
+            <meta itemprop="description" content="Club Brugge 2025-2026 Third shirt - Romeo Vermant #11, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, Third, Romeo Vermant, 11">
+            <h3>Club Brugge 2025-2026 Third shirt - Romeo Vermant #11 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt132.1.jpg" alt="Club Brugge 2025-2026 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt132.2.jpg" alt="Club Brugge 2025-2026 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt132.1.jpg" alt="Club Brugge 2025-2026 Third shirt worn by or printed for Romeo Vermant number 11" title="Club Brugge 2025-2026 Third shirt - Romeo Vermant #11 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Third shirt worn by or printed for Romeo Vermant number 11">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt132.2.jpg" alt="Club Brugge 2025-2026 Third shirt worn by or printed for Romeo Vermant number 11" title="Club Brugge 2025-2026 Third shirt - Romeo Vermant #11 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 Third shirt worn by or printed for Romeo Vermant number 11">
+                </figure>
+
             </div>
             <div class="player-info">Player: Romeo Vermant - Number: 11</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Romeo Vermant</dd><dt>Number</dt><dd>11</dd></dl>
+        </article>
+
         <!-- Shirt 6 (ID: 130) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2025-2026 GK 2 - Size: L</h3>
+        <article id="shirt-130" class="shirt-section" data-collectible="matchworn" data-player="nordin jackers" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29">
+            <meta itemprop="description" content="Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29, Size L, Matchworn, signed by Nordin Jackers.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2025-2026, GK 2, Nordin Jackers, 29, Matchworn">
+            <h3>Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt122.1.jpg" alt="Club Brugge 2025-2026 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt122.2.jpg" alt="Club Brugge 2025-2026 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt122.3.jpg" alt="Club Brugge 2025-2026 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt122.1.jpg" alt="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn" title="Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt122.2.jpg" alt="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn" title="Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt122.3.jpg" alt="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn" title="Club Brugge 2025-2026 GK 2 shirt - Nordin Jackers #29 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2025-2026 GK 2 shirt worn by or printed for Nordin Jackers number 29 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Nordin Jackers - Number: 29</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2025-2026</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Nordin Jackers</dd><dt>Number</dt><dd>29</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Nordin Jackers</dd></dl>
+        </article>
+
         <!-- Shirt 7 (ID: 129) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Home - Size: 2XL</h3>
+        <article id="shirt-129" class="shirt-section" data-collectible="signed" data-player="christos tzolis" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Home shirt - Christos Tzolis #8">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Home shirt - Christos Tzolis #8, Size 2XL, Signed, signed by Christos Tzolis.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Home, Christos Tzolis, 8, Signed">
+            <h3>Club Brugge 2024-2025 Home shirt - Christos Tzolis #8 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt47.1.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt47.2.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt47.1.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2024-2025 Home shirt - Christos Tzolis #8 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt47.2.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2024-2025 Home shirt - Christos Tzolis #8 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Christos Tzolis - Number: 8</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Christos Tzolis</dd><dt>Number</dt><dd>8</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Christos Tzolis</dd></dl>
+        </article>
+
         <!-- Shirt 8 (ID: 128) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Home - Size: M</h3>
+        <article id="shirt-128" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Home shirt, Size M, Signed, signed by Squad signed.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Home, Signed">
+            <h3>Club Brugge 2024-2025 Home shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt69.1.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt69.2.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt69.1.jpg" alt="Club Brugge 2024-2025 Home shirt Signed" title="Club Brugge 2024-2025 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt69.2.jpg" alt="Club Brugge 2024-2025 Home shirt Signed" title="Club Brugge 2024-2025 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Squad signed</dd></dl>
+        </article>
+
         <!-- Shirt 9 (ID: 127) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2024-2025 Home - Size: M</h3>
+        <article id="shirt-127" class="shirt-section" data-collectible="matchworn" data-player="chemsdine talbi" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68, Size M, Matchworn, signed by Chemsdine Talbi.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Home, Chemsdine Talbi, 68, Matchworn">
+            <h3>Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt76.1.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt76.2.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt76.3.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt76.1.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn" title="Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt76.2.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn" title="Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt76.3.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn" title="Club Brugge 2024-2025 Home shirt - Chemsdine Talbi #68 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Chemsdine Talbi number 68 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Chemsdine Talbi - Number: 68</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Chemsdine Talbi</dd><dt>Number</dt><dd>68</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Chemsdine Talbi</dd></dl>
+        </article>
+
         <!-- Shirt 10 (ID: 126) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Home - Size: S</h3>
+        <article id="shirt-126" class="shirt-section" data-collectible="signed" data-player="brandon mechele" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Home shirt - Brandon Mechele #44">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Home shirt - Brandon Mechele #44, Size S, Signed, signed by Brandon Mechele.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Home, Brandon Mechele, 44, Signed">
+            <h3>Club Brugge 2024-2025 Home shirt - Brandon Mechele #44 - Size: S</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt100.1.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt100.2.jpg" alt="Club Brugge 2024-2025 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt100.1.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Brandon Mechele number 44 Signed" title="Club Brugge 2024-2025 Home shirt - Brandon Mechele #44 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Brandon Mechele number 44 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt100.2.jpg" alt="Club Brugge 2024-2025 Home shirt worn by or printed for Brandon Mechele number 44 Signed" title="Club Brugge 2024-2025 Home shirt - Brandon Mechele #44 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Home shirt worn by or printed for Brandon Mechele number 44 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Brandon Mechele - Number: 44</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>S</dd><dt>Player</dt><dd>Brandon Mechele</dd><dt>Number</dt><dd>44</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Brandon Mechele</dd></dl>
+        </article>
+
         <!-- Shirt 11 (ID: 125) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Away - Size: XL</h3>
+        <article id="shirt-125" class="shirt-section" data-collectible="signed" data-player="hans vanaken" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Away shirt - Hans Vanaken #20">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Away shirt - Hans Vanaken #20, Size XL, Signed, signed by Hans Vanaken.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Away, Hans Vanaken, 20, Signed">
+            <h3>Club Brugge 2024-2025 Away shirt - Hans Vanaken #20 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt5.1.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt5.2.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt5.3.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt5.1.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed" title="Club Brugge 2024-2025 Away shirt - Hans Vanaken #20 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt5.2.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed" title="Club Brugge 2024-2025 Away shirt - Hans Vanaken #20 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt5.3.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed" title="Club Brugge 2024-2025 Away shirt - Hans Vanaken #20 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Hans Vanaken number 20 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Hans Vanaken - Number: 20</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Hans Vanaken</dd><dt>Number</dt><dd>20</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Hans Vanaken</dd></dl>
+        </article>
+
         <!-- Shirt 12 (ID: 124) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Away - Size: XL</h3>
+        <article id="shirt-124" class="shirt-section" data-collectible="signed" data-player="ardon jashari" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Away shirt - Ardon Jashari #30">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Away shirt - Ardon Jashari #30, Size XL, Signed, signed by Ardon Jashari.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Away, Ardon Jashari, 30, Signed">
+            <h3>Club Brugge 2024-2025 Away shirt - Ardon Jashari #30 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt101.1.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt101.2.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt101.3.jpg" alt="Club Brugge 2024-2025 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt101.1.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed" title="Club Brugge 2024-2025 Away shirt - Ardon Jashari #30 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt101.2.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed" title="Club Brugge 2024-2025 Away shirt - Ardon Jashari #30 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt101.3.jpg" alt="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed" title="Club Brugge 2024-2025 Away shirt - Ardon Jashari #30 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Away shirt worn by or printed for Ardon Jashari number 30 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ardon Jashari - Number: 30</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Ardon Jashari</dd><dt>Number</dt><dd>30</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Ardon Jashari</dd></dl>
+        </article>
+
         <!-- Shirt 13 (ID: 123) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2024-2025 Third - Size: XL</h3>
+        <article id="shirt-123" class="shirt-section" data-collectible="signed" data-player="christos tzolis" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Third shirt - Christos Tzolis #8">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Third shirt - Christos Tzolis #8, Size XL, Signed, signed by Christos Tzolis.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Third, Christos Tzolis, 8, Signed">
+            <h3>Club Brugge 2024-2025 Third shirt - Christos Tzolis #8 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt66.1.jpg" alt="Club Brugge 2024-2025 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt66.2.jpg" alt="Club Brugge 2024-2025 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt66.1.jpg" alt="Club Brugge 2024-2025 Third shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2024-2025 Third shirt - Christos Tzolis #8 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Third shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt66.2.jpg" alt="Club Brugge 2024-2025 Third shirt worn by or printed for Christos Tzolis number 8 Signed" title="Club Brugge 2024-2025 Third shirt - Christos Tzolis #8 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Third shirt worn by or printed for Christos Tzolis number 8 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Christos Tzolis - Number: 8</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Christos Tzolis</dd><dt>Number</dt><dd>8</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Christos Tzolis</dd></dl>
+        </article>
+
         <!-- Shirt 14 (ID: 122) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2024-2025 Third - Size: XL</h3>
+        <article id="shirt-122" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2024-2025 Third shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, Third">
+            <h3>Club Brugge 2024-2025 Third shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt98.1.jpg" alt="Club Brugge 2024-2025 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt98.2.jpg" alt="Club Brugge 2024-2025 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt98.1.jpg" alt="Club Brugge 2024-2025 Third shirt" title="Club Brugge 2024-2025 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Third shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt98.2.jpg" alt="Club Brugge 2024-2025 Third shirt" title="Club Brugge 2024-2025 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 Third shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 15 (ID: 121) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2024-2025 GK 2 - Size: M</h3>
+        <article id="shirt-121" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 GK 2 shirt">
+            <meta itemprop="description" content="Club Brugge 2024-2025 GK 2 shirt, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, GK 2">
+            <h3>Club Brugge 2024-2025 GK 2 shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt123.1.jpg" alt="Club Brugge 2024-2025 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt123.2.jpg" alt="Club Brugge 2024-2025 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt123.1.jpg" alt="Club Brugge 2024-2025 GK 2 shirt" title="Club Brugge 2024-2025 GK 2 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 GK 2 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt123.2.jpg" alt="Club Brugge 2024-2025 GK 2 shirt" title="Club Brugge 2024-2025 GK 2 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 GK 2 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>M</dd></dl>
+        </article>
+
         <!-- Shirt 16 (ID: 120) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2024-2025 GK 3 - Size: M</h3>
+        <article id="shirt-120" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2024-2025 GK 3 shirt">
+            <meta itemprop="description" content="Club Brugge 2024-2025 GK 3 shirt, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2024-2025, GK 3">
+            <h3>Club Brugge 2024-2025 GK 3 shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt124.1.jpg" alt="Club Brugge 2024-2025 GK 3 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt124.2.jpg" alt="Club Brugge 2024-2025 GK 3 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt124.1.jpg" alt="Club Brugge 2024-2025 GK 3 shirt" title="Club Brugge 2024-2025 GK 3 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 GK 3 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt124.2.jpg" alt="Club Brugge 2024-2025 GK 3 shirt" title="Club Brugge 2024-2025 GK 3 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2024-2025 GK 3 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2024-2025</dd><dt>Type</dt><dd>GK 3</dd><dt>Size</dt><dd>M</dd></dl>
+        </article>
+
         <!-- Shirt 17 (ID: 119) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2023-2024 Home - Size: M</h3>
+        <article id="shirt-119" class="shirt-section" data-collectible="matchworn" data-player="philip zinckernagel" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77, Size M, Matchworn, signed by Philip Zinckernagel.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Home, Philip Zinckernagel, 77, Matchworn">
+            <h3>Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt77.1.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt77.2.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt77.3.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt77.1.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn" title="Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt77.2.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn" title="Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt77.3.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn" title="Club Brugge 2023-2024 Home shirt - Philip Zinckernagel #77 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Philip Zinckernagel number 77 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Philip Zinckernagel - Number: 77</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Philip Zinckernagel</dd><dt>Number</dt><dd>77</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Philip Zinckernagel</dd></dl>
+        </article>
+
         <!-- Shirt 18 (ID: 118) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2023-2024 Home - Size: 2XL</h3>
+        <article id="shirt-118" class="shirt-section" data-collectible="signed" data-player="hans vanaken" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Home shirt - Hans Vanaken #20">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Home shirt - Hans Vanaken #20, Size 2XL, Signed, signed by Hans Vanaken.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Home, Hans Vanaken, 20, Signed">
+            <h3>Club Brugge 2023-2024 Home shirt - Hans Vanaken #20 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt43.1.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt43.2.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt43.1.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Hans Vanaken number 20 Signed" title="Club Brugge 2023-2024 Home shirt - Hans Vanaken #20 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Hans Vanaken number 20 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt43.2.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Hans Vanaken number 20 Signed" title="Club Brugge 2023-2024 Home shirt - Hans Vanaken #20 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Hans Vanaken number 20 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Hans Vanaken - Number: 20</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Hans Vanaken</dd><dt>Number</dt><dd>20</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Hans Vanaken</dd></dl>
+        </article>
+
         <!-- Shirt 19 (ID: 117) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2023-2024 Home - Size: M</h3>
+        <article id="shirt-117" class="shirt-section" data-collectible="signed" data-player="casper nielsen" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Home shirt - Casper Nielsen #27">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Home shirt - Casper Nielsen #27, Size M, Signed, signed by Casper Nielsen.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Home, Casper Nielsen, 27, Signed">
+            <h3>Club Brugge 2023-2024 Home shirt - Casper Nielsen #27 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt102.1.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt102.2.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt102.1.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Casper Nielsen number 27 Signed" title="Club Brugge 2023-2024 Home shirt - Casper Nielsen #27 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Casper Nielsen number 27 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt102.2.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Casper Nielsen number 27 Signed" title="Club Brugge 2023-2024 Home shirt - Casper Nielsen #27 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Casper Nielsen number 27 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Casper Nielsen - Number: 27</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Casper Nielsen</dd><dt>Number</dt><dd>27</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Casper Nielsen</dd></dl>
+        </article>
+
         <!-- Shirt 20 (ID: 116) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2023-2024 Home - Size: XL</h3>
+        <article id="shirt-116" class="shirt-section" data-player="igor thiago" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Home shirt - Igor Thiago #99">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Home shirt - Igor Thiago #99, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Home, Igor Thiago, 99">
+            <h3>Club Brugge 2023-2024 Home shirt - Igor Thiago #99 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt111.1.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt111.2.jpg" alt="Club Brugge 2023-2024 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt111.1.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Igor Thiago number 99" title="Club Brugge 2023-2024 Home shirt - Igor Thiago #99 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Igor Thiago number 99">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt111.2.jpg" alt="Club Brugge 2023-2024 Home shirt worn by or printed for Igor Thiago number 99" title="Club Brugge 2023-2024 Home shirt - Igor Thiago #99 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Home shirt worn by or printed for Igor Thiago number 99">
+                </figure>
+
             </div>
             <div class="player-info">Player: Igor Thiago - Number: 99</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Igor Thiago</dd><dt>Number</dt><dd>99</dd></dl>
+        </article>
+
         <!-- Shirt 21 (ID: 115) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2023-2024 Away - Size: XL</h3>
+        <article id="shirt-115" class="shirt-section" data-collectible="signed" data-player="brandon mechele" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Away shirt - Brandon Mechele #44">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Away shirt - Brandon Mechele #44, Size XL, Signed, signed by Brandon Mechele.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Away, Brandon Mechele, 44, Signed">
+            <h3>Club Brugge 2023-2024 Away shirt - Brandon Mechele #44 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt61.1.jpg" alt="Club Brugge 2023-2024 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt61.2.jpg" alt="Club Brugge 2023-2024 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt61.1.jpg" alt="Club Brugge 2023-2024 Away shirt worn by or printed for Brandon Mechele number 44 Signed" title="Club Brugge 2023-2024 Away shirt - Brandon Mechele #44 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Away shirt worn by or printed for Brandon Mechele number 44 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt61.2.jpg" alt="Club Brugge 2023-2024 Away shirt worn by or printed for Brandon Mechele number 44 Signed" title="Club Brugge 2023-2024 Away shirt - Brandon Mechele #44 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Away shirt worn by or printed for Brandon Mechele number 44 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Brandon Mechele - Number: 44</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Brandon Mechele</dd><dt>Number</dt><dd>44</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Brandon Mechele</dd></dl>
+        </article>
+
         <!-- Shirt 22 (ID: 114) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2023-2024 Third - Size: XL</h3>
+        <article id="shirt-114" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Third shirt, Size XL, Signed, signed by Vetlesen, Skoras, Hayen, Seys, Mignolet, De Corte, Onyedika, Nielsen, De Cuyper, Meijer, Et Taïbi, Nilsson, Nusa, Talbi, Spileers, Jackers, Vermant, Boyata, Mechele, Tzolis, Zinckernagel.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Third, Signed">
+            <h3>Club Brugge 2023-2024 Third shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt65.1.jpg" alt="Club Brugge 2023-2024 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt65.2.jpg" alt="Club Brugge 2023-2024 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt65.1.jpg" alt="Club Brugge 2023-2024 Third shirt Signed" title="Club Brugge 2023-2024 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Third shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt65.2.jpg" alt="Club Brugge 2023-2024 Third shirt Signed" title="Club Brugge 2023-2024 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Third shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Vetlesen, Skoras, Hayen, Seys, Mignolet, De Corte, Onyedika, Nielsen, De Cuyper, Meijer, Et Taïbi, Nilsson, Nusa, Talbi, Spileers, Jackers, Vermant, Boyata, Mechele, Tzolis, Zinckernagel</dd></dl>
+        </article>
+
         <!-- Shirt 23 (ID: 113) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2023-2024 Fourth - Size: L</h3>
+        <article id="shirt-113" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 Fourth shirt">
+            <meta itemprop="description" content="Club Brugge 2023-2024 Fourth shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, Fourth">
+            <h3>Club Brugge 2023-2024 Fourth shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt78.1.jpg" alt="Club Brugge 2023-2024 Fourth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt78.2.jpg" alt="Club Brugge 2023-2024 Fourth shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt78.1.jpg" alt="Club Brugge 2023-2024 Fourth shirt" title="Club Brugge 2023-2024 Fourth shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Fourth shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt78.2.jpg" alt="Club Brugge 2023-2024 Fourth shirt" title="Club Brugge 2023-2024 Fourth shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 Fourth shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>Fourth</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 24 (ID: 112) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2023-2024 GK 3 - Size: XL</h3>
+        <article id="shirt-112" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2023-2024 GK 3 shirt">
+            <meta itemprop="description" content="Club Brugge 2023-2024 GK 3 shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2023-2024, GK 3">
+            <h3>Club Brugge 2023-2024 GK 3 shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt68.1.jpg" alt="Club Brugge 2023-2024 GK 3 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt68.2.jpg" alt="Club Brugge 2023-2024 GK 3 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt68.1.jpg" alt="Club Brugge 2023-2024 GK 3 shirt" title="Club Brugge 2023-2024 GK 3 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 GK 3 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt68.2.jpg" alt="Club Brugge 2023-2024 GK 3 shirt" title="Club Brugge 2023-2024 GK 3 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2023-2024 GK 3 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2023-2024</dd><dt>Type</dt><dd>GK 3</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 25 (ID: 111) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 Home - Size: XL</h3>
+        <article id="shirt-111" class="shirt-section" data-collectible="signed" data-player="mats rits" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Home shirt - Mats Rits #26">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Home shirt - Mats Rits #26, Size XL, Signed, signed by Squad signed.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Home, Mats Rits, 26, Signed">
+            <h3>Club Brugge 2022-2023 Home shirt - Mats Rits #26 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt64.1.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt64.2.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt64.3.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt64.1.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed" title="Club Brugge 2022-2023 Home shirt - Mats Rits #26 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt64.2.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed" title="Club Brugge 2022-2023 Home shirt - Mats Rits #26 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt64.3.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed" title="Club Brugge 2022-2023 Home shirt - Mats Rits #26 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Mats Rits number 26 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Mats Rits - Number: 26</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Mats Rits</dd><dt>Number</dt><dd>26</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Squad signed</dd></dl>
+        </article>
+
         <!-- Shirt 26 (ID: 110) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 Home - Size: L</h3>
+        <article id="shirt-110" class="shirt-section" data-collectible="signed" data-player="jorne spileers" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Home shirt - Jorne Spileers #27">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Home shirt - Jorne Spileers #27, Size L, Signed, signed by Spileers.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Home, Jorne Spileers, 27, Signed">
+            <h3>Club Brugge 2022-2023 Home shirt - Jorne Spileers #27 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt79.1.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt79.2.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt79.3.jpg" alt="Club Brugge 2022-2023 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt79.1.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed" title="Club Brugge 2022-2023 Home shirt - Jorne Spileers #27 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt79.2.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed" title="Club Brugge 2022-2023 Home shirt - Jorne Spileers #27 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt79.3.jpg" alt="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed" title="Club Brugge 2022-2023 Home shirt - Jorne Spileers #27 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Home shirt worn by or printed for Jorne Spileers number 27 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Jorne Spileers - Number: 27</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Jorne Spileers</dd><dt>Number</dt><dd>27</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Spileers</dd></dl>
+        </article>
+
         <!-- Shirt 27 (ID: 109) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2022-2023 Away - Size: L</h3>
+        <article id="shirt-109" class="shirt-section" data-player="abakar sylla" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Away shirt - Abakar Sylla #94">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Away shirt - Abakar Sylla #94, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Away, Abakar Sylla, 94">
+            <h3>Club Brugge 2022-2023 Away shirt - Abakar Sylla #94 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt80.1.jpg" alt="Club Brugge 2022-2023 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt80.2.jpg" alt="Club Brugge 2022-2023 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt80.1.jpg" alt="Club Brugge 2022-2023 Away shirt worn by or printed for Abakar Sylla number 94" title="Club Brugge 2022-2023 Away shirt - Abakar Sylla #94 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Away shirt worn by or printed for Abakar Sylla number 94">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt80.2.jpg" alt="Club Brugge 2022-2023 Away shirt worn by or printed for Abakar Sylla number 94" title="Club Brugge 2022-2023 Away shirt - Abakar Sylla #94 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Away shirt worn by or printed for Abakar Sylla number 94">
+                </figure>
+
             </div>
             <div class="player-info">Player: Abakar Sylla - Number: 94</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Abakar Sylla</dd><dt>Number</dt><dd>94</dd></dl>
+        </article>
+
         <!-- Shirt 28 (ID: 108) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 Away - Size: L</h3>
+        <article id="shirt-108" class="shirt-section" data-collectible="signed" data-player="joel ordóñez" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4, Size L, Signed, signed by Joel Ordóñez.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Away, Joel Ordóñez, 4, Signed">
+            <h3>Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt63.1.jpg" alt="Club Brugge 2022-2023 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt63.2.jpg" alt="Club Brugge 2022-2023 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt63.3.jpg" alt="Club Brugge 2022-2023 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt63.1.jpg" alt="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed" title="Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt63.2.jpg" alt="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed" title="Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt63.3.jpg" alt="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed" title="Club Brugge 2022-2023 Away shirt - Joel Ordóñez #4 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Away shirt worn by or printed for Joel Ordóñez number 4 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Joel Ordóñez - Number: 4</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Joel Ordóñez</dd><dt>Number</dt><dd>4</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Joel Ordóñez</dd></dl>
+        </article>
+
         <!-- Shirt 29 (ID: 107) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2022-2023 Third - Size: M</h3>
+        <article id="shirt-107" class="shirt-section" data-collectible="matchworn" data-player="kamal sowah" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Third shirt - Kamal Sowah #19">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Third shirt - Kamal Sowah #19, Size M, Matchworn, signed by Kamal Sowah.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Third, Kamal Sowah, 19, Matchworn">
+            <h3>Club Brugge 2022-2023 Third shirt - Kamal Sowah #19 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt125.1.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt125.2.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt125.3.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt125.1.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn" title="Club Brugge 2022-2023 Third shirt - Kamal Sowah #19 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt125.2.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn" title="Club Brugge 2022-2023 Third shirt - Kamal Sowah #19 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt125.3.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn" title="Club Brugge 2022-2023 Third shirt - Kamal Sowah #19 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Kamal Sowah number 19 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Kamal Sowah - Number: 19</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Kamal Sowah</dd><dt>Number</dt><dd>19</dd><dt>Status</dt><dd>Matchworn</dd><dt>Signatures</dt><dd>Kamal Sowah</dd></dl>
+        </article>
+
         <!-- Shirt 30 (ID: 106) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 Third - Size: XL</h3>
+        <article id="shirt-106" class="shirt-section" data-collectible="signed" data-player="ferran jutglà blanch" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9, Size XL, Signed, signed by Ferran Jutglà Blanch.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Third, Ferran Jutglà Blanch, 9, Signed">
+            <h3>Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt81.1.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt81.2.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt81.1.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Ferran Jutglà Blanch number 9 Signed" title="Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Ferran Jutglà Blanch number 9 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt81.2.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Ferran Jutglà Blanch number 9 Signed" title="Club Brugge 2022-2023 Third shirt - Ferran Jutglà Blanch #9 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Ferran Jutglà Blanch number 9 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ferran Jutglà Blanch - Number: 9</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Ferran Jutglà Blanch</dd><dt>Number</dt><dd>9</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Ferran Jutglà Blanch</dd></dl>
+        </article>
+
         <!-- Shirt 31 (ID: 105) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 Third - Size: L</h3>
+        <article id="shirt-105" class="shirt-section" data-collectible="signed" data-player="casper nielsen" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 Third shirt - Casper Nielsen #27">
+            <meta itemprop="description" content="Club Brugge 2022-2023 Third shirt - Casper Nielsen #27, Size L, Signed, signed by Casper Nielsen.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, Third, Casper Nielsen, 27, Signed">
+            <h3>Club Brugge 2022-2023 Third shirt - Casper Nielsen #27 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt99.1.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt99.2.jpg" alt="Club Brugge 2022-2023 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt99.1.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Casper Nielsen number 27 Signed" title="Club Brugge 2022-2023 Third shirt - Casper Nielsen #27 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Casper Nielsen number 27 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt99.2.jpg" alt="Club Brugge 2022-2023 Third shirt worn by or printed for Casper Nielsen number 27 Signed" title="Club Brugge 2022-2023 Third shirt - Casper Nielsen #27 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 Third shirt worn by or printed for Casper Nielsen number 27 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Casper Nielsen - Number: 27</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Casper Nielsen</dd><dt>Number</dt><dd>27</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Casper Nielsen</dd></dl>
+        </article>
+
         <!-- Shirt 32 (ID: 104) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2022-2023 GK 1 - Size: 2XL</h3>
+        <article id="shirt-104" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 GK 1 shirt">
+            <meta itemprop="description" content="Club Brugge 2022-2023 GK 1 shirt, Size 2XL, Signed, signed by Mignolet.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, GK 1, Signed">
+            <h3>Club Brugge 2022-2023 GK 1 shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt60.1.jpg" alt="Club Brugge 2022-2023 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt60.2.jpg" alt="Club Brugge 2022-2023 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt60.1.jpg" alt="Club Brugge 2022-2023 GK 1 shirt Signed" title="Club Brugge 2022-2023 GK 1 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 GK 1 shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt60.2.jpg" alt="Club Brugge 2022-2023 GK 1 shirt Signed" title="Club Brugge 2022-2023 GK 1 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 GK 1 shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>2XL</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Mignolet</dd></dl>
+        </article>
+
         <!-- Shirt 33 (ID: 103) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2022-2023 GK 2 - Size: M</h3>
+        <article id="shirt-103" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2022-2023 GK 2 shirt">
+            <meta itemprop="description" content="Club Brugge 2022-2023 GK 2 shirt, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2022-2023, GK 2">
+            <h3>Club Brugge 2022-2023 GK 2 shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt59.1.jpg" alt="Club Brugge 2022-2023 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt59.2.jpg" alt="Club Brugge 2022-2023 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt59.1.jpg" alt="Club Brugge 2022-2023 GK 2 shirt" title="Club Brugge 2022-2023 GK 2 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 GK 2 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt59.2.jpg" alt="Club Brugge 2022-2023 GK 2 shirt" title="Club Brugge 2022-2023 GK 2 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2022-2023 GK 2 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2022-2023</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>M</dd></dl>
+        </article>
+
         <!-- Shirt 34 (ID: 102) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2021-2022 Home - Size: M</h3>
+        <article id="shirt-102" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Home shirt, Size M, Signed, signed by De Ketelaere, Rits, Hoefkens, Jutgla, Skov Olsen, Sowah, Audoor, Meijer, Vanaken, Vormer, Sylla, Nusa, Mbamba, Shinton, Okereke, Nsoki, Balanta, Lammens, Izquierdo, Mata, Buchanan, Mechele, Lang, Sobol, Dost, Schreuder, Mignolet, Ricca, Sandra.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Home, Signed">
+            <h3>Club Brugge 2021-2022 Home shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt58.1.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt58.2.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt58.1.jpg" alt="Club Brugge 2021-2022 Home shirt Signed" title="Club Brugge 2021-2022 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt58.2.jpg" alt="Club Brugge 2021-2022 Home shirt Signed" title="Club Brugge 2021-2022 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>De Ketelaere, Rits, Hoefkens, Jutgla, Skov Olsen, Sowah, Audoor, Meijer, Vanaken, Vormer, Sylla, Nusa, Mbamba, Shinton, Okereke, Nsoki, Balanta, Lammens, Izquierdo, Mata, Buchanan, Mechele, Lang, Sobol, Dost, Schreuder, Mignolet, Ricca, Sandra</dd></dl>
+        </article>
+
         <!-- Shirt 35 (ID: 101) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 Home - Size: 2XL</h3>
+        <article id="shirt-101" class="shirt-section" data-player="hans vanaken" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Home shirt - Hans Vanaken #20">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Home shirt - Hans Vanaken #20, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Home, Hans Vanaken, 20">
+            <h3>Club Brugge 2021-2022 Home shirt - Hans Vanaken #20 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt48.1.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt48.2.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt48.1.jpg" alt="Club Brugge 2021-2022 Home shirt worn by or printed for Hans Vanaken number 20" title="Club Brugge 2021-2022 Home shirt - Hans Vanaken #20 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt worn by or printed for Hans Vanaken number 20">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt48.2.jpg" alt="Club Brugge 2021-2022 Home shirt worn by or printed for Hans Vanaken number 20" title="Club Brugge 2021-2022 Home shirt - Hans Vanaken #20 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt worn by or printed for Hans Vanaken number 20">
+                </figure>
+
             </div>
             <div class="player-info">Player: Hans Vanaken - Number: 20</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Hans Vanaken</dd><dt>Number</dt><dd>20</dd></dl>
+        </article>
+
         <!-- Shirt 36 (ID: 100) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 Home - Size: XL</h3>
+        <article id="shirt-100" class="shirt-section" data-player="tajon buchanan" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Home, Tajon Buchanan, 17">
+            <h3>Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt56.1.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt56.2.jpg" alt="Club Brugge 2021-2022 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt56.1.jpg" alt="Club Brugge 2021-2022 Home shirt worn by or printed for Tajon Buchanan number 17" title="Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt worn by or printed for Tajon Buchanan number 17">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt56.2.jpg" alt="Club Brugge 2021-2022 Home shirt worn by or printed for Tajon Buchanan number 17" title="Club Brugge 2021-2022 Home shirt - Tajon Buchanan #17 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Home shirt worn by or printed for Tajon Buchanan number 17">
+                </figure>
+
             </div>
             <div class="player-info">Player: Tajon Buchanan - Number: 17</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Tajon Buchanan</dd><dt>Number</dt><dd>17</dd></dl>
+        </article>
+
         <!-- Shirt 37 (ID: 99) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2021-2022 Away - Size: 2XL</h3>
+        <article id="shirt-99" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Away shirt, Size 2XL, Signed, signed by Nusa, Bursik, Jutgla, Thiago, Mechele, Spileers, De Cuyper, Barbera, Meijer, Jackers, Homma, Vetlesen, Shinton, Mignolet, Talbi, Onyedika, Balanta, Ordonez.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Away, Signed">
+            <h3>Club Brugge 2021-2022 Away shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt54.1.jpg" alt="Club Brugge 2021-2022 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt54.2.jpg" alt="Club Brugge 2021-2022 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt54.1.jpg" alt="Club Brugge 2021-2022 Away shirt Signed" title="Club Brugge 2021-2022 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt54.2.jpg" alt="Club Brugge 2021-2022 Away shirt Signed" title="Club Brugge 2021-2022 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Nusa, Bursik, Jutgla, Thiago, Mechele, Spileers, De Cuyper, Barbera, Meijer, Jackers, Homma, Vetlesen, Shinton, Mignolet, Talbi, Onyedika, Balanta, Ordonez</dd></dl>
+        </article>
+
         <!-- Shirt 38 (ID: 98) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 Away - Size: M</h3>
+        <article id="shirt-98" class="shirt-section" data-player="eduard sobol" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Away shirt - Eduard sobol #2">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Away shirt - Eduard sobol #2, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Away, Eduard sobol, 2">
+            <h3>Club Brugge 2021-2022 Away shirt - Eduard sobol #2 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt126.1.jpg" alt="Club Brugge 2021-2022 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt126.2.jpg" alt="Club Brugge 2021-2022 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt126.1.jpg" alt="Club Brugge 2021-2022 Away shirt worn by or printed for Eduard sobol number 2" title="Club Brugge 2021-2022 Away shirt - Eduard sobol #2 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away shirt worn by or printed for Eduard sobol number 2">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt126.2.jpg" alt="Club Brugge 2021-2022 Away shirt worn by or printed for Eduard sobol number 2" title="Club Brugge 2021-2022 Away shirt - Eduard sobol #2 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away shirt worn by or printed for Eduard sobol number 2">
+                </figure>
+
             </div>
             <div class="player-info">Player: Eduard sobol - Number: 2</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Eduard sobol</dd><dt>Number</dt><dd>2</dd></dl>
+        </article>
+
         <!-- Shirt 39 (ID: 97) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 Away Youth - Size: M</h3>
+        <article id="shirt-97" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Away Youth shirt - #15">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Away Youth shirt - #15, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Away Youth, 15">
+            <h3>Club Brugge 2021-2022 Away Youth shirt - #15 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt18.1.jpg" alt="Club Brugge 2021-2022 Away Youth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt18.2.jpg" alt="Club Brugge 2021-2022 Away Youth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt18.3.jpg" alt="Club Brugge 2021-2022 Away Youth shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt18.1.jpg" alt="Club Brugge 2021-2022 Away Youth shirt number 15" title="Club Brugge 2021-2022 Away Youth shirt - #15 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away Youth shirt number 15">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt18.2.jpg" alt="Club Brugge 2021-2022 Away Youth shirt number 15" title="Club Brugge 2021-2022 Away Youth shirt - #15 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away Youth shirt number 15">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt18.3.jpg" alt="Club Brugge 2021-2022 Away Youth shirt number 15" title="Club Brugge 2021-2022 Away Youth shirt - #15 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Away Youth shirt number 15">
+                </figure>
+
             </div>
-        </div>
-        
+            <div class="player-info">Number: 15</div>
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Away Youth</dd><dt>Size</dt><dd>M</dd><dt>Number</dt><dd>15</dd></dl>
+        </article>
+
         <!-- Shirt 40 (ID: 96) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 Third - Size: L</h3>
+        <article id="shirt-96" class="shirt-section" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 Third shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2021-2022 Third shirt - Ruud Vormer #25, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, Third, Ruud Vormer, 25">
+            <h3>Club Brugge 2021-2022 Third shirt - Ruud Vormer #25 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt52.1.jpg" alt="Club Brugge 2021-2022 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt52.2.jpg" alt="Club Brugge 2021-2022 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt52.1.jpg" alt="Club Brugge 2021-2022 Third shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2021-2022 Third shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Third shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt52.2.jpg" alt="Club Brugge 2021-2022 Third shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2021-2022 Third shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 Third shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd></dl>
+        </article>
+
         <!-- Shirt 41 (ID: 95) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2021-2022 GK 1 - Size: XL</h3>
+        <article id="shirt-95" class="shirt-section" data-collectible="signed" data-player="simon mignolet" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22">
+            <meta itemprop="description" content="Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22, Size XL, Signed, signed by Simon Mignolet.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, GK 1, Simon Mignolet, 22, Signed">
+            <h3>Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt39.1.jpg" alt="Club Brugge 2021-2022 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt39.2.jpg" alt="Club Brugge 2021-2022 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt39.1.jpg" alt="Club Brugge 2021-2022 GK 1 shirt worn by or printed for Simon Mignolet number 22 Signed" title="Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 GK 1 shirt worn by or printed for Simon Mignolet number 22 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt39.2.jpg" alt="Club Brugge 2021-2022 GK 1 shirt worn by or printed for Simon Mignolet number 22 Signed" title="Club Brugge 2021-2022 GK 1 shirt - Simon Mignolet #22 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 GK 1 shirt worn by or printed for Simon Mignolet number 22 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Simon Mignolet - Number: 22</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Simon Mignolet</dd><dt>Number</dt><dd>22</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Simon Mignolet</dd></dl>
+        </article>
+
         <!-- Shirt 42 (ID: 94) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2021-2022 GK 2 - Size: L</h3>
+        <article id="shirt-94" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2021-2022 GK 2 shirt">
+            <meta itemprop="description" content="Club Brugge 2021-2022 GK 2 shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2021-2022, GK 2">
+            <h3>Club Brugge 2021-2022 GK 2 shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt92.1.jpg" alt="Club Brugge 2021-2022 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt92.2.jpg" alt="Club Brugge 2021-2022 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt92.1.jpg" alt="Club Brugge 2021-2022 GK 2 shirt" title="Club Brugge 2021-2022 GK 2 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 GK 2 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt92.2.jpg" alt="Club Brugge 2021-2022 GK 2 shirt" title="Club Brugge 2021-2022 GK 2 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2021-2022 GK 2 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2021-2022</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 43 (ID: 93) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2020-2021 Home - Size: S</h3>
+        <article id="shirt-93" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Home shirt, Size S, Signed, signed by Charles De Ketelaere.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Home, Signed">
+            <h3>Club Brugge 2020-2021 Home shirt - Size: S</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt50.1.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt50.2.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt50.3.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt50.1.jpg" alt="Club Brugge 2020-2021 Home shirt Signed" title="Club Brugge 2020-2021 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt50.2.jpg" alt="Club Brugge 2020-2021 Home shirt Signed" title="Club Brugge 2020-2021 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt50.3.jpg" alt="Club Brugge 2020-2021 Home shirt Signed" title="Club Brugge 2020-2021 Home shirt photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>S</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Charles De Ketelaere</dd></dl>
+        </article>
+
         <!-- Shirt 44 (ID: 92) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2020-2021 Home Youth - Size: M</h3>
+        <article id="shirt-92" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Home Youth shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Home Youth shirt, Size M, Signed, signed by Squad signed.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Home Youth, Signed">
+            <h3>Club Brugge 2020-2021 Home Youth shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt119.1.jpg" alt="Club Brugge 2020-2021 Home Youth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt119.2.jpg" alt="Club Brugge 2020-2021 Home Youth shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt119.1.jpg" alt="Club Brugge 2020-2021 Home Youth shirt Signed" title="Club Brugge 2020-2021 Home Youth shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home Youth shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt119.2.jpg" alt="Club Brugge 2020-2021 Home Youth shirt Signed" title="Club Brugge 2020-2021 Home Youth shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home Youth shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Home Youth</dd><dt>Size</dt><dd>M</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Squad signed</dd></dl>
+        </article>
+
         <!-- Shirt 45 (ID: 91) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 Home - Size: 2XL</h3>
+        <article id="shirt-91" class="shirt-section" data-player="clinton mata" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Home shirt - Clinton Mata #77">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Home shirt - Clinton Mata #77, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Home, Clinton Mata, 77">
+            <h3>Club Brugge 2020-2021 Home shirt - Clinton Mata #77 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt110.1.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt110.2.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt110.1.jpg" alt="Club Brugge 2020-2021 Home shirt worn by or printed for Clinton Mata number 77" title="Club Brugge 2020-2021 Home shirt - Clinton Mata #77 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt worn by or printed for Clinton Mata number 77">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt110.2.jpg" alt="Club Brugge 2020-2021 Home shirt worn by or printed for Clinton Mata number 77" title="Club Brugge 2020-2021 Home shirt - Clinton Mata #77 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt worn by or printed for Clinton Mata number 77">
+                </figure>
+
             </div>
             <div class="player-info">Player: Clinton Mata - Number: 77</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Clinton Mata</dd><dt>Number</dt><dd>77</dd></dl>
+        </article>
+
         <!-- Shirt 46 (ID: 90) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 Home - Size: 2XL</h3>
+        <article id="shirt-90" class="shirt-section" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Home shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Home shirt - Ruud Vormer #25, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Home, Ruud Vormer, 25">
+            <h3>Club Brugge 2020-2021 Home shirt - Ruud Vormer #25 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt109.1.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt109.2.jpg" alt="Club Brugge 2020-2021 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt109.1.jpg" alt="Club Brugge 2020-2021 Home shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2020-2021 Home shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt109.2.jpg" alt="Club Brugge 2020-2021 Home shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2020-2021 Home shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Home shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd></dl>
+        </article>
+
         <!-- Shirt 47 (ID: 89) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2020-2021 Away - Size: M</h3>
+        <article id="shirt-89" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Away shirt, Size M, Signed, signed by Lambert, Lang, De ketelaere, Mignolet, Odoi, Skov Olsen, Lammens, Mata, Buchanan, Balanta, Sobol, Otasowie.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Away, Signed">
+            <h3>Club Brugge 2020-2021 Away shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt49.1.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt49.2.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt49.1.jpg" alt="Club Brugge 2020-2021 Away shirt Signed" title="Club Brugge 2020-2021 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt49.2.jpg" alt="Club Brugge 2020-2021 Away shirt Signed" title="Club Brugge 2020-2021 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>M</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Lambert, Lang, De ketelaere, Mignolet, Odoi, Skov Olsen, Lammens, Mata, Buchanan, Balanta, Sobol, Otasowie</dd></dl>
+        </article>
+
         <!-- Shirt 48 (ID: 88) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 Away - Size: 3XL</h3>
+        <article id="shirt-88" class="shirt-section" data-player="simon mignolet" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Away shirt - Simon Mignolet #88">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Away shirt - Simon Mignolet #88, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Away, Simon Mignolet, 88">
+            <h3>Club Brugge 2020-2021 Away shirt - Simon Mignolet #88 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt117.1.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt117.2.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt117.1.jpg" alt="Club Brugge 2020-2021 Away shirt worn by or printed for Simon Mignolet number 88" title="Club Brugge 2020-2021 Away shirt - Simon Mignolet #88 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt worn by or printed for Simon Mignolet number 88">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt117.2.jpg" alt="Club Brugge 2020-2021 Away shirt worn by or printed for Simon Mignolet number 88" title="Club Brugge 2020-2021 Away shirt - Simon Mignolet #88 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt worn by or printed for Simon Mignolet number 88">
+                </figure>
+
             </div>
             <div class="player-info">Player: Simon Mignolet - Number: 88</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Simon Mignolet</dd><dt>Number</dt><dd>88</dd></dl>
+        </article>
+
         <!-- Shirt 49 (ID: 87) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 Away - Size: L</h3>
+        <article id="shirt-87" class="shirt-section" data-player="stefano denswil" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Away shirt - Stefano Denswil #24">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Away shirt - Stefano Denswil #24, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Away, Stefano Denswil, 24">
+            <h3>Club Brugge 2020-2021 Away shirt - Stefano Denswil #24 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt83.1.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt83.2.jpg" alt="Club Brugge 2020-2021 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt83.1.jpg" alt="Club Brugge 2020-2021 Away shirt worn by or printed for Stefano Denswil number 24" title="Club Brugge 2020-2021 Away shirt - Stefano Denswil #24 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt worn by or printed for Stefano Denswil number 24">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt83.2.jpg" alt="Club Brugge 2020-2021 Away shirt worn by or printed for Stefano Denswil number 24" title="Club Brugge 2020-2021 Away shirt - Stefano Denswil #24 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Away shirt worn by or printed for Stefano Denswil number 24">
+                </figure>
+
             </div>
             <div class="player-info">Player: Stefano Denswil - Number: 24</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Stefano Denswil</dd><dt>Number</dt><dd>24</dd></dl>
+        </article>
+
         <!-- Shirt 50 (ID: 86) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2020-2021 Third - Size: 2XL</h3>
+        <article id="shirt-86" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 Third shirt, Size 2XL, Signed, signed by Vanaken, Vetlesen, Vermant, Nillsson, Siquet, De Cuyper, Hayen, Talbi, Romero, Onyedika, Odoi, Meijer, Seys, Ordonez, Audoor, Jashari.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, Third, Signed">
+            <h3>Club Brugge 2020-2021 Third shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt57.1.jpg" alt="Club Brugge 2020-2021 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt57.2.jpg" alt="Club Brugge 2020-2021 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt57.3.jpg" alt="Club Brugge 2020-2021 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt57.1.jpg" alt="Club Brugge 2020-2021 Third shirt Signed" title="Club Brugge 2020-2021 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Third shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt57.2.jpg" alt="Club Brugge 2020-2021 Third shirt Signed" title="Club Brugge 2020-2021 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Third shirt Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt57.3.jpg" alt="Club Brugge 2020-2021 Third shirt Signed" title="Club Brugge 2020-2021 Third shirt photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 Third shirt Signed">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>2XL</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Vanaken, Vetlesen, Vermant, Nillsson, Siquet, De Cuyper, Hayen, Talbi, Romero, Onyedika, Odoi, Meijer, Seys, Ordonez, Audoor, Jashari</dd></dl>
+        </article>
+
         <!-- Shirt 51 (ID: 85) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 GK 1 - Size: L</h3>
+        <article id="shirt-85" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 GK 1 shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 GK 1 shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, GK 1">
+            <h3>Club Brugge 2020-2021 GK 1 shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt46.1.jpg" alt="Club Brugge 2020-2021 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt46.2.jpg" alt="Club Brugge 2020-2021 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt46.1.jpg" alt="Club Brugge 2020-2021 GK 1 shirt" title="Club Brugge 2020-2021 GK 1 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 GK 1 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt46.2.jpg" alt="Club Brugge 2020-2021 GK 1 shirt" title="Club Brugge 2020-2021 GK 1 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 GK 1 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 52 (ID: 84) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2020-2021 GK 2 - Size: L</h3>
+        <article id="shirt-84" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2020-2021 GK 2 shirt">
+            <meta itemprop="description" content="Club Brugge 2020-2021 GK 2 shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2020-2021, GK 2">
+            <h3>Club Brugge 2020-2021 GK 2 shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt127.1.jpg" alt="Club Brugge 2020-2021 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt127.2.jpg" alt="Club Brugge 2020-2021 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt127.1.jpg" alt="Club Brugge 2020-2021 GK 2 shirt" title="Club Brugge 2020-2021 GK 2 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 GK 2 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt127.2.jpg" alt="Club Brugge 2020-2021 GK 2 shirt" title="Club Brugge 2020-2021 GK 2 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2020-2021 GK 2 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2020-2021</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 53 (ID: 83) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Home - Size: 3XL</h3>
+        <article id="shirt-83" class="shirt-section" data-player="clinton mata" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Home shirt - Clinton Mata #77">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Home shirt - Clinton Mata #77, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Home, Clinton Mata, 77">
+            <h3>Club Brugge 2019-2020 Home shirt - Clinton Mata #77 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt116.1.jpg" alt="Club Brugge 2019-2020 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt116.2.jpg" alt="Club Brugge 2019-2020 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt116.1.jpg" alt="Club Brugge 2019-2020 Home shirt worn by or printed for Clinton Mata number 77" title="Club Brugge 2019-2020 Home shirt - Clinton Mata #77 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Home shirt worn by or printed for Clinton Mata number 77">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt116.2.jpg" alt="Club Brugge 2019-2020 Home shirt worn by or printed for Clinton Mata number 77" title="Club Brugge 2019-2020 Home shirt - Clinton Mata #77 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Home shirt worn by or printed for Clinton Mata number 77">
+                </figure>
+
             </div>
             <div class="player-info">Player: Clinton Mata - Number: 77</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Clinton Mata</dd><dt>Number</dt><dd>77</dd></dl>
+        </article>
+
         <!-- Shirt 54 (ID: 82) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Home - Size: 2XL</h3>
+        <article id="shirt-82" class="shirt-section" data-player="eduard sobol" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Home shirt - Eduard Sobol #2">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Home shirt - Eduard Sobol #2, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Home, Eduard Sobol, 2">
+            <h3>Club Brugge 2019-2020 Home shirt - Eduard Sobol #2 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt45.1.jpg" alt="Club Brugge 2019-2020 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt45.2.jpg" alt="Club Brugge 2019-2020 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt45.3.jpg" alt="Club Brugge 2019-2020 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt45.1.jpg" alt="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2" title="Club Brugge 2019-2020 Home shirt - Eduard Sobol #2 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt45.2.jpg" alt="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2" title="Club Brugge 2019-2020 Home shirt - Eduard Sobol #2 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt45.3.jpg" alt="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2" title="Club Brugge 2019-2020 Home shirt - Eduard Sobol #2 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Home shirt worn by or printed for Eduard Sobol number 2">
+                </figure>
+
             </div>
             <div class="player-info">Player: Eduard Sobol - Number: 2</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Eduard Sobol</dd><dt>Number</dt><dd>2</dd></dl>
+        </article>
+
         <!-- Shirt 55 (ID: 81) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Away - Size: XL</h3>
+        <article id="shirt-81" class="shirt-section" data-player="charles de ketelaere" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Away, Charles De Ketelaere, 90">
+            <h3>Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt84.1.jpg" alt="Club Brugge 2019-2020 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt84.2.jpg" alt="Club Brugge 2019-2020 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt84.1.jpg" alt="Club Brugge 2019-2020 Away shirt worn by or printed for Charles De Ketelaere number 90" title="Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Away shirt worn by or printed for Charles De Ketelaere number 90">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt84.2.jpg" alt="Club Brugge 2019-2020 Away shirt worn by or printed for Charles De Ketelaere number 90" title="Club Brugge 2019-2020 Away shirt - Charles De Ketelaere #90 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Away shirt worn by or printed for Charles De Ketelaere number 90">
+                </figure>
+
             </div>
             <div class="player-info">Player: Charles De Ketelaere - Number: 90</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Charles De Ketelaere</dd><dt>Number</dt><dd>90</dd></dl>
+        </article>
+
         <!-- Shirt 56 (ID: 80) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Third - Size: M</h3>
+        <article id="shirt-80" class="shirt-section" data-player="charles de ketelaere" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Third, Charles De Ketelaere, 90">
+            <h3>Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt85.1.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt85.2.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt85.1.jpg" alt="Club Brugge 2019-2020 Third shirt worn by or printed for Charles De Ketelaere number 90" title="Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt worn by or printed for Charles De Ketelaere number 90">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt85.2.jpg" alt="Club Brugge 2019-2020 Third shirt worn by or printed for Charles De Ketelaere number 90" title="Club Brugge 2019-2020 Third shirt - Charles De Ketelaere #90 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt worn by or printed for Charles De Ketelaere number 90">
+                </figure>
+
             </div>
             <div class="player-info">Player: Charles De Ketelaere - Number: 90</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Charles De Ketelaere</dd><dt>Number</dt><dd>90</dd></dl>
+        </article>
+
         <!-- Shirt 57 (ID: 79) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Third - Size: 3XL</h3>
+        <article id="shirt-79" class="shirt-section" data-player="simon deli" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Third shirt - Simon Deli #17">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Third shirt - Simon Deli #17, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Third, Simon Deli, 17">
+            <h3>Club Brugge 2019-2020 Third shirt - Simon Deli #17 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt118.1.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt118.2.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt118.1.jpg" alt="Club Brugge 2019-2020 Third shirt worn by or printed for Simon Deli number 17" title="Club Brugge 2019-2020 Third shirt - Simon Deli #17 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt worn by or printed for Simon Deli number 17">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt118.2.jpg" alt="Club Brugge 2019-2020 Third shirt worn by or printed for Simon Deli number 17" title="Club Brugge 2019-2020 Third shirt - Simon Deli #17 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt worn by or printed for Simon Deli number 17">
+                </figure>
+
             </div>
             <div class="player-info">Player: Simon Deli - Number: 17</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Simon Deli</dd><dt>Number</dt><dd>17</dd></dl>
+        </article>
+
         <!-- Shirt 58 (ID: 78) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2019-2020 Third - Size: 3XL</h3>
+        <article id="shirt-78" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2019-2020 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2019-2020 Third shirt, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2019-2020, Third">
+            <h3>Club Brugge 2019-2020 Third shirt - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt86.1.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt86.2.jpg" alt="Club Brugge 2019-2020 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt86.1.jpg" alt="Club Brugge 2019-2020 Third shirt" title="Club Brugge 2019-2020 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt86.2.jpg" alt="Club Brugge 2019-2020 Third shirt" title="Club Brugge 2019-2020 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2019-2020 Third shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2019-2020</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>3XL</dd></dl>
+        </article>
+
         <!-- Shirt 59 (ID: 77) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2018-2019 Home - Size: M</h3>
+        <article id="shirt-77" class="shirt-section" data-collectible="matchworn" data-player="arnaut danjuma" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47, Size M, Matchworn.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Home, Arnaut Danjuma, 47, Matchworn">
+            <h3>Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt108.1.jpg" alt="Club Brugge 2018-2019 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt108.2.jpg" alt="Club Brugge 2018-2019 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt108.3.jpg" alt="Club Brugge 2018-2019 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt108.1.jpg" alt="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn" title="Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt108.2.jpg" alt="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn" title="Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt108.3.jpg" alt="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn" title="Club Brugge 2018-2019 Home shirt - Arnaut Danjuma #47 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Home shirt worn by or printed for Arnaut Danjuma number 47 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Arnaut Danjuma - Number: 47</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Arnaut Danjuma</dd><dt>Number</dt><dd>47</dd><dt>Status</dt><dd>Matchworn</dd></dl>
+        </article>
+
         <!-- Shirt 60 (ID: 76) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Home - Size: M</h3>
+        <article id="shirt-76" class="shirt-section" data-player="sofyan amrabat" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Home, Sofyan Amrabat, 6">
+            <h3>Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt41.1.jpg" alt="Club Brugge 2018-2019 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt41.2.jpg" alt="Club Brugge 2018-2019 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt41.1.jpg" alt="Club Brugge 2018-2019 Home shirt worn by or printed for Sofyan Amrabat number 6" title="Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Home shirt worn by or printed for Sofyan Amrabat number 6">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt41.2.jpg" alt="Club Brugge 2018-2019 Home shirt worn by or printed for Sofyan Amrabat number 6" title="Club Brugge 2018-2019 Home shirt - Sofyan Amrabat #6 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Home shirt worn by or printed for Sofyan Amrabat number 6">
+                </figure>
+
             </div>
             <div class="player-info">Player: Sofyan Amrabat - Number: 6</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Sofyan Amrabat</dd><dt>Number</dt><dd>6</dd></dl>
+        </article>
+
         <!-- Shirt 61 (ID: 75) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Away - Size: XL</h3>
+        <article id="shirt-75" class="shirt-section" data-player="jelle vossen" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Away shirt - Jelle Vossen #9">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Away shirt - Jelle Vossen #9, Size XL, signed by Jelle Vossen.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Away, Jelle Vossen, 9">
+            <h3>Club Brugge 2018-2019 Away shirt - Jelle Vossen #9 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt40.1.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt40.2.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt40.3.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt40.1.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9" title="Club Brugge 2018-2019 Away shirt - Jelle Vossen #9 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt40.2.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9" title="Club Brugge 2018-2019 Away shirt - Jelle Vossen #9 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt40.3.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9" title="Club Brugge 2018-2019 Away shirt - Jelle Vossen #9 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Jelle Vossen number 9">
+                </figure>
+
             </div>
             <div class="player-info">Player: Jelle Vossen - Number: 9</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Jelle Vossen</dd><dt>Number</dt><dd>9</dd><dt>Signatures</dt><dd>Jelle Vossen</dd></dl>
+        </article>
+
         <!-- Shirt 62 (ID: 74) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Away - Size: L</h3>
+        <article id="shirt-74" class="shirt-section" data-player="loïs openda" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Away shirt - Loïs Openda #80">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Away shirt - Loïs Openda #80, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Away, Loïs Openda, 80">
+            <h3>Club Brugge 2018-2019 Away shirt - Loïs Openda #80 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt87.1.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt87.2.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt87.1.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Loïs Openda number 80" title="Club Brugge 2018-2019 Away shirt - Loïs Openda #80 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Loïs Openda number 80">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt87.2.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Loïs Openda number 80" title="Club Brugge 2018-2019 Away shirt - Loïs Openda #80 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Loïs Openda number 80">
+                </figure>
+
             </div>
             <div class="player-info">Player: Loïs Openda - Number: 80</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Loïs Openda</dd><dt>Number</dt><dd>80</dd></dl>
+        </article>
+
         <!-- Shirt 63 (ID: 73) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Away - Size: 2XL</h3>
+        <article id="shirt-73" class="shirt-section" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Away shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Away shirt - Ruud Vormer #25, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Away, Ruud Vormer, 25">
+            <h3>Club Brugge 2018-2019 Away shirt - Ruud Vormer #25 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt1.1.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt1.2.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt1.1.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2018-2019 Away shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt1.2.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2018-2019 Away shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd></dl>
+        </article>
+
         <!-- Shirt 64 (ID: 72) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Away - Size: 4XL</h3>
+        <article id="shirt-72" class="shirt-section" data-player="arnaut danjuma" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47, Size 4XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Away, Arnaut Danjuma, 47">
+            <h3>Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47 - Size: 4XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt115.1.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt115.2.jpg" alt="Club Brugge 2018-2019 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt115.1.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Arnaut Danjuma number 47" title="Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Arnaut Danjuma number 47">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt115.2.jpg" alt="Club Brugge 2018-2019 Away shirt worn by or printed for Arnaut Danjuma number 47" title="Club Brugge 2018-2019 Away shirt - Arnaut Danjuma #47 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Away shirt worn by or printed for Arnaut Danjuma number 47">
+                </figure>
+
             </div>
             <div class="player-info">Player: Arnaut Danjuma - Number: 47</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>4XL</dd><dt>Player</dt><dd>Arnaut Danjuma</dd><dt>Number</dt><dd>47</dd></dl>
+        </article>
+
         <!-- Shirt 65 (ID: 71) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Third - Size: 3XL</h3>
+        <article id="shirt-71" class="shirt-section" data-player="krépin diatta" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Third shirt - Krépin Diatta #11">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Third shirt - Krépin Diatta #11, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Third, Krépin Diatta, 11">
+            <h3>Club Brugge 2018-2019 Third shirt - Krépin Diatta #11 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt62.1.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt62.2.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt62.1.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Krépin Diatta number 11" title="Club Brugge 2018-2019 Third shirt - Krépin Diatta #11 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Krépin Diatta number 11">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt62.2.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Krépin Diatta number 11" title="Club Brugge 2018-2019 Third shirt - Krépin Diatta #11 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Krépin Diatta number 11">
+                </figure>
+
             </div>
             <div class="player-info">Player: Krépin Diatta - Number: 11</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Krépin Diatta</dd><dt>Number</dt><dd>11</dd></dl>
+        </article>
+
         <!-- Shirt 66 (ID: 70) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2018-2019 Third - Size: M</h3>
+        <article id="shirt-70" class="shirt-section" data-player="emmanuel dennis bonaventure" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Third, Emmanuel Dennis Bonaventure, 42">
+            <h3>Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt55.1.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt55.2.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt55.1.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Emmanuel Dennis Bonaventure number 42" title="Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Emmanuel Dennis Bonaventure number 42">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt55.2.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Emmanuel Dennis Bonaventure number 42" title="Club Brugge 2018-2019 Third shirt - Emmanuel Dennis Bonaventure #42 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Emmanuel Dennis Bonaventure number 42">
+                </figure>
+
             </div>
             <div class="player-info">Player: Emmanuel Dennis Bonaventure - Number: 42</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Emmanuel Dennis Bonaventure</dd><dt>Number</dt><dd>42</dd></dl>
+        </article>
+
         <!-- Shirt 67 (ID: 69) -->
-        <div class="shirt-section" data-collectible="framed">
-            <h3>Club Brugge 2018-2019 Third - Size: 2XL</h3>
+        <article id="shirt-69" class="shirt-section" data-collectible="framed" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2018-2019 Third shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2018-2019 Third shirt - Ruud Vormer #25, Size 2XL, Framed, signed by Ruud Vormer.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2018-2019, Third, Ruud Vormer, 25, Framed">
+            <h3>Club Brugge 2018-2019 Third shirt - Ruud Vormer #25 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt38.1.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt38.2.jpg" alt="Club Brugge 2018-2019 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt38.1.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Ruud Vormer number 25 Framed" title="Club Brugge 2018-2019 Third shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Ruud Vormer number 25 Framed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt38.2.jpg" alt="Club Brugge 2018-2019 Third shirt worn by or printed for Ruud Vormer number 25 Framed" title="Club Brugge 2018-2019 Third shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2018-2019 Third shirt worn by or printed for Ruud Vormer number 25 Framed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
+
             <div class="collectible-info">Status: Framed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2018-2019</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd><dt>Status</dt><dd>Framed</dd><dt>Signatures</dt><dd>Ruud Vormer</dd></dl>
+        </article>
+
         <!-- Shirt 68 (ID: 68) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2017-2018 Home - Size: XL</h3>
+        <article id="shirt-68" class="shirt-section" data-collectible="matchworn" data-player="wesley moraes" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Home shirt - Wesley Moraes #7">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Home shirt - Wesley Moraes #7, Size XL, Matchworn.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Home, Wesley Moraes, 7, Matchworn">
+            <h3>Club Brugge 2017-2018 Home shirt - Wesley Moraes #7 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt107.1.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt107.2.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt107.3.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt107.1.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn" title="Club Brugge 2017-2018 Home shirt - Wesley Moraes #7 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt107.2.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn" title="Club Brugge 2017-2018 Home shirt - Wesley Moraes #7 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt107.3.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn" title="Club Brugge 2017-2018 Home shirt - Wesley Moraes #7 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Wesley Moraes number 7 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Wesley Moraes - Number: 7</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Wesley Moraes</dd><dt>Number</dt><dd>7</dd><dt>Status</dt><dd>Matchworn</dd></dl>
+        </article>
+
         <!-- Shirt 69 (ID: 67) -->
-        <div class="shirt-section" data-collectible="matchworn">
-            <h3>Club Brugge 2017-2018 Home - Size: L</h3>
+        <article id="shirt-67" class="shirt-section" data-collectible="matchworn" data-player="stefano denswil" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Home shirt - Stefano Denswil #24">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Home shirt - Stefano Denswil #24, Size L, Matchworn.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Home, Stefano Denswil, 24, Matchworn">
+            <h3>Club Brugge 2017-2018 Home shirt - Stefano Denswil #24 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt106.1.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt106.2.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt106.3.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt106.1.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn" title="Club Brugge 2017-2018 Home shirt - Stefano Denswil #24 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt106.2.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn" title="Club Brugge 2017-2018 Home shirt - Stefano Denswil #24 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt106.3.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn" title="Club Brugge 2017-2018 Home shirt - Stefano Denswil #24 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Stefano Denswil number 24 Matchworn">
+                </figure>
+
             </div>
             <div class="player-info">Player: Stefano Denswil - Number: 24</div>
-            
+
             <div class="collectible-info">Status: Matchworn</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Stefano Denswil</dd><dt>Number</dt><dd>24</dd><dt>Status</dt><dd>Matchworn</dd></dl>
+        </article>
+
         <!-- Shirt 70 (ID: 66) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 Home - Size: 2XL</h3>
+        <article id="shirt-66" class="shirt-section" data-player="hans vanaken" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Home shirt - Hans Vanaken #20">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Home shirt - Hans Vanaken #20, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Home, Hans Vanaken, 20">
+            <h3>Club Brugge 2017-2018 Home shirt - Hans Vanaken #20 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt36.1.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt36.2.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt36.1.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Hans Vanaken number 20" title="Club Brugge 2017-2018 Home shirt - Hans Vanaken #20 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Hans Vanaken number 20">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt36.2.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Hans Vanaken number 20" title="Club Brugge 2017-2018 Home shirt - Hans Vanaken #20 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Hans Vanaken number 20">
+                </figure>
+
             </div>
             <div class="player-info">Player: Hans Vanaken - Number: 20</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Hans Vanaken</dd><dt>Number</dt><dd>20</dd></dl>
+        </article>
+
         <!-- Shirt 71 (ID: 65) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 Home - Size: 3XL</h3>
+        <article id="shirt-65" class="shirt-section" data-player="timmy simons" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Home shirt - Timmy Simons #3">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Home shirt - Timmy Simons #3, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Home, Timmy Simons, 3">
+            <h3>Club Brugge 2017-2018 Home shirt - Timmy Simons #3 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt44.1.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt44.2.jpg" alt="Club Brugge 2017-2018 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt44.1.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2017-2018 Home shirt - Timmy Simons #3 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt44.2.jpg" alt="Club Brugge 2017-2018 Home shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2017-2018 Home shirt - Timmy Simons #3 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Home shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
             </div>
             <div class="player-info">Player: Timmy Simons - Number: 3</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Timmy Simons</dd><dt>Number</dt><dd>3</dd></dl>
+        </article>
+
         <!-- Shirt 72 (ID: 64) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2017-2018 Away - Size: XL</h3>
+        <article id="shirt-64" class="shirt-section" data-collectible="signed" data-player="marvelous nakamba" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30, Size XL, Signed, signed by Marvelous Nakamba.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Away, Marvelous Nakamba, 30, Signed">
+            <h3>Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt35.1.jpg" alt="Club Brugge 2017-2018 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt35.2.jpg" alt="Club Brugge 2017-2018 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt35.1.jpg" alt="Club Brugge 2017-2018 Away shirt worn by or printed for Marvelous Nakamba number 30 Signed" title="Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Away shirt worn by or printed for Marvelous Nakamba number 30 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt35.2.jpg" alt="Club Brugge 2017-2018 Away shirt worn by or printed for Marvelous Nakamba number 30 Signed" title="Club Brugge 2017-2018 Away shirt - Marvelous Nakamba #30 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Away shirt worn by or printed for Marvelous Nakamba number 30 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Marvelous Nakamba - Number: 30</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Marvelous Nakamba</dd><dt>Number</dt><dd>30</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Marvelous Nakamba</dd></dl>
+        </article>
+
         <!-- Shirt 73 (ID: 63) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 Away - Size: L</h3>
+        <article id="shirt-63" class="shirt-section" data-player="emmanuel dennis bonaventure" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Away, Emmanuel Dennis Bonaventure, 42">
+            <h3>Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt34.1.jpg" alt="Club Brugge 2017-2018 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt34.2.jpg" alt="Club Brugge 2017-2018 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt34.1.jpg" alt="Club Brugge 2017-2018 Away shirt worn by or printed for Emmanuel Dennis Bonaventure number 42" title="Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Away shirt worn by or printed for Emmanuel Dennis Bonaventure number 42">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt34.2.jpg" alt="Club Brugge 2017-2018 Away shirt worn by or printed for Emmanuel Dennis Bonaventure number 42" title="Club Brugge 2017-2018 Away shirt - Emmanuel Dennis Bonaventure #42 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Away shirt worn by or printed for Emmanuel Dennis Bonaventure number 42">
+                </figure>
+
             </div>
             <div class="player-info">Player: Emmanuel Dennis Bonaventure - Number: 42</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Emmanuel Dennis Bonaventure</dd><dt>Number</dt><dd>42</dd></dl>
+        </article>
+
         <!-- Shirt 74 (ID: 62) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2017-2018 Third - Size: XL</h3>
+        <article id="shirt-62" class="shirt-section" data-collectible="signed" data-player="marvelous nakamba" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30, Size XL, Signed, signed by Marvelous Nakamba.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Third, Marvelous Nakamba, 30, Signed">
+            <h3>Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt33.1.jpg" alt="Club Brugge 2017-2018 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt33.2.jpg" alt="Club Brugge 2017-2018 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt33.1.jpg" alt="Club Brugge 2017-2018 Third shirt worn by or printed for Marvelous Nakamba number 30 Signed" title="Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Third shirt worn by or printed for Marvelous Nakamba number 30 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt33.2.jpg" alt="Club Brugge 2017-2018 Third shirt worn by or printed for Marvelous Nakamba number 30 Signed" title="Club Brugge 2017-2018 Third shirt - Marvelous Nakamba #30 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Third shirt worn by or printed for Marvelous Nakamba number 30 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Marvelous Nakamba - Number: 30</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Marvelous Nakamba</dd><dt>Number</dt><dd>30</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Marvelous Nakamba</dd></dl>
+        </article>
+
         <!-- Shirt 75 (ID: 61) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 Fourth - Size: 2XL</h3>
+        <article id="shirt-61" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 Fourth shirt">
+            <meta itemprop="description" content="Club Brugge 2017-2018 Fourth shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, Fourth">
+            <h3>Club Brugge 2017-2018 Fourth shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt31.1.jpg" alt="Club Brugge 2017-2018 Fourth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt31.2.jpg" alt="Club Brugge 2017-2018 Fourth shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt31.1.jpg" alt="Club Brugge 2017-2018 Fourth shirt" title="Club Brugge 2017-2018 Fourth shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Fourth shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt31.2.jpg" alt="Club Brugge 2017-2018 Fourth shirt" title="Club Brugge 2017-2018 Fourth shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 Fourth shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>Fourth</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 76 (ID: 60) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 GK 1 - Size: M</h3>
+        <article id="shirt-60" class="shirt-section" data-player="ludovic butelle" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1">
+            <meta itemprop="description" content="Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, GK 1, Ludovic Butelle, 1">
+            <h3>Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt135.1.jpg" alt="Club Brugge 2017-2018 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt135.2.jpg" alt="Club Brugge 2017-2018 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt135.1.jpg" alt="Club Brugge 2017-2018 GK 1 shirt worn by or printed for Ludovic Butelle number 1" title="Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 1 shirt worn by or printed for Ludovic Butelle number 1">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt135.2.jpg" alt="Club Brugge 2017-2018 GK 1 shirt worn by or printed for Ludovic Butelle number 1" title="Club Brugge 2017-2018 GK 1 shirt - Ludovic Butelle #1 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 1 shirt worn by or printed for Ludovic Butelle number 1">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ludovic Butelle - Number: 1</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Ludovic Butelle</dd><dt>Number</dt><dd>1</dd></dl>
+        </article>
+
         <!-- Shirt 77 (ID: 59) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 GK 3 - Size: 2XL</h3>
+        <article id="shirt-59" class="shirt-section" data-player="ludovic butelle" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1">
+            <meta itemprop="description" content="Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, GK 3, Ludovic Butelle, 1">
+            <h3>Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt112.1.jpg" alt="Club Brugge 2017-2018 GK 3 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt112.2.jpg" alt="Club Brugge 2017-2018 GK 3 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt112.1.jpg" alt="Club Brugge 2017-2018 GK 3 shirt worn by or printed for Ludovic Butelle number 1" title="Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 3 shirt worn by or printed for Ludovic Butelle number 1">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt112.2.jpg" alt="Club Brugge 2017-2018 GK 3 shirt worn by or printed for Ludovic Butelle number 1" title="Club Brugge 2017-2018 GK 3 shirt - Ludovic Butelle #1 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 3 shirt worn by or printed for Ludovic Butelle number 1">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ludovic Butelle - Number: 1</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>GK 3</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Ludovic Butelle</dd><dt>Number</dt><dd>1</dd></dl>
+        </article>
+
         <!-- Shirt 78 (ID: 58) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2017-2018 GK 4 - Size: L</h3>
+        <article id="shirt-58" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2017-2018 GK 4 shirt">
+            <meta itemprop="description" content="Club Brugge 2017-2018 GK 4 shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2017-2018, GK 4">
+            <h3>Club Brugge 2017-2018 GK 4 shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt32.1.jpg" alt="Club Brugge 2017-2018 GK 4 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt32.2.jpg" alt="Club Brugge 2017-2018 GK 4 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt32.1.jpg" alt="Club Brugge 2017-2018 GK 4 shirt" title="Club Brugge 2017-2018 GK 4 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 4 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt32.2.jpg" alt="Club Brugge 2017-2018 GK 4 shirt" title="Club Brugge 2017-2018 GK 4 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2017-2018 GK 4 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2017-2018</dd><dt>Type</dt><dd>GK 4</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 79 (ID: 57) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Home - Size: XL</h3>
+        <article id="shirt-57" class="shirt-section" data-player="josé izquierdo" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Home shirt - José Izquierdo #11">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Home shirt - José Izquierdo #11, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Home, José Izquierdo, 11">
+            <h3>Club Brugge 2016-2017 Home shirt - José Izquierdo #11 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt30.1.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt30.2.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt30.3.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt30.1.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11" title="Club Brugge 2016-2017 Home shirt - José Izquierdo #11 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt30.2.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11" title="Club Brugge 2016-2017 Home shirt - José Izquierdo #11 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt30.3.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11" title="Club Brugge 2016-2017 Home shirt - José Izquierdo #11 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for José Izquierdo number 11">
+                </figure>
+
             </div>
             <div class="player-info">Player: José Izquierdo - Number: 11</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>José Izquierdo</dd><dt>Number</dt><dd>11</dd></dl>
+        </article>
+
         <!-- Shirt 80 (ID: 56) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Home - Size: XL</h3>
+        <article id="shirt-56" class="shirt-section" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Home shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Home shirt - Ruud Vormer #25, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Home, Ruud Vormer, 25">
+            <h3>Club Brugge 2016-2017 Home shirt - Ruud Vormer #25 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt29.1.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt29.2.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt29.1.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2016-2017 Home shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt29.2.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2016-2017 Home shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd></dl>
+        </article>
+
         <!-- Shirt 81 (ID: 55) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Home - Size: 2XL</h3>
+        <article id="shirt-55" class="shirt-section" data-player="timmy simons" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Home shirt - Timmy Simons #3">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Home shirt - Timmy Simons #3, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Home, Timmy Simons, 3">
+            <h3>Club Brugge 2016-2017 Home shirt - Timmy Simons #3 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt37.1.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt37.2.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt37.1.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2016-2017 Home shirt - Timmy Simons #3 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt37.2.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2016-2017 Home shirt - Timmy Simons #3 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
             </div>
             <div class="player-info">Player: Timmy Simons - Number: 3</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Timmy Simons</dd><dt>Number</dt><dd>3</dd></dl>
+        </article>
+
         <!-- Shirt 82 (ID: 54) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Home - Size: XL</h3>
+        <article id="shirt-54" class="shirt-section" data-player="dorin rotariu" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Home, Dorin Rotariu, 29">
+            <h3>Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt120.1.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt120.2.jpg" alt="Club Brugge 2016-2017 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt120.1.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Dorin Rotariu number 29" title="Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Dorin Rotariu number 29">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt120.2.jpg" alt="Club Brugge 2016-2017 Home shirt worn by or printed for Dorin Rotariu number 29" title="Club Brugge 2016-2017 Home shirt - Dorin Rotariu #29 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Home shirt worn by or printed for Dorin Rotariu number 29">
+                </figure>
+
             </div>
             <div class="player-info">Player: Dorin Rotariu - Number: 29</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Dorin Rotariu</dd><dt>Number</dt><dd>29</dd></dl>
+        </article>
+
         <!-- Shirt 83 (ID: 53) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Away - Size: 2XL</h3>
+        <article id="shirt-53" class="shirt-section" data-player="timmy simons" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Away shirt - Timmy Simons #3">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Away shirt - Timmy Simons #3, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Away, Timmy Simons, 3">
+            <h3>Club Brugge 2016-2017 Away shirt - Timmy Simons #3 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt23.1.jpg" alt="Club Brugge 2016-2017 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt23.2.jpg" alt="Club Brugge 2016-2017 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt23.1.jpg" alt="Club Brugge 2016-2017 Away shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2016-2017 Away shirt - Timmy Simons #3 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Away shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt23.2.jpg" alt="Club Brugge 2016-2017 Away shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2016-2017 Away shirt - Timmy Simons #3 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Away shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
             </div>
             <div class="player-info">Player: Timmy Simons - Number: 3</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Timmy Simons</dd><dt>Number</dt><dd>3</dd></dl>
+        </article>
+
         <!-- Shirt 84 (ID: 52) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 Third - Size: XL</h3>
+        <article id="shirt-52" class="shirt-section" data-player="ruud vormer" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 Third shirt - Ruud Vormer #25">
+            <meta itemprop="description" content="Club Brugge 2016-2017 Third shirt - Ruud Vormer #25, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, Third, Ruud Vormer, 25">
+            <h3>Club Brugge 2016-2017 Third shirt - Ruud Vormer #25 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt28.1.jpg" alt="Club Brugge 2016-2017 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt28.2.jpg" alt="Club Brugge 2016-2017 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt28.1.jpg" alt="Club Brugge 2016-2017 Third shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2016-2017 Third shirt - Ruud Vormer #25 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Third shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt28.2.jpg" alt="Club Brugge 2016-2017 Third shirt worn by or printed for Ruud Vormer number 25" title="Club Brugge 2016-2017 Third shirt - Ruud Vormer #25 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 Third shirt worn by or printed for Ruud Vormer number 25">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ruud Vormer - Number: 25</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Ruud Vormer</dd><dt>Number</dt><dd>25</dd></dl>
+        </article>
+
         <!-- Shirt 85 (ID: 51) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2016-2017 GK 2 - Size: XL</h3>
+        <article id="shirt-51" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2016-2017 GK 2 shirt">
+            <meta itemprop="description" content="Club Brugge 2016-2017 GK 2 shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2016-2017, GK 2">
+            <h3>Club Brugge 2016-2017 GK 2 shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt22.1.jpg" alt="Club Brugge 2016-2017 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt22.2.jpg" alt="Club Brugge 2016-2017 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt22.1.jpg" alt="Club Brugge 2016-2017 GK 2 shirt" title="Club Brugge 2016-2017 GK 2 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 GK 2 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt22.2.jpg" alt="Club Brugge 2016-2017 GK 2 shirt" title="Club Brugge 2016-2017 GK 2 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2016-2017 GK 2 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2016-2017</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 86 (ID: 50) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2015-2016 Away - Size: L</h3>
+        <article id="shirt-50" class="shirt-section" data-player="dion cools" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2015-2016 Away shirt - Dion Cools #21">
+            <meta itemprop="description" content="Club Brugge 2015-2016 Away shirt - Dion Cools #21, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2015-2016, Away, Dion Cools, 21">
+            <h3>Club Brugge 2015-2016 Away shirt - Dion Cools #21 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt21.1.jpg" alt="Club Brugge 2015-2016 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt21.2.jpg" alt="Club Brugge 2015-2016 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt21.1.jpg" alt="Club Brugge 2015-2016 Away shirt worn by or printed for Dion Cools number 21" title="Club Brugge 2015-2016 Away shirt - Dion Cools #21 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2015-2016 Away shirt worn by or printed for Dion Cools number 21">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt21.2.jpg" alt="Club Brugge 2015-2016 Away shirt worn by or printed for Dion Cools number 21" title="Club Brugge 2015-2016 Away shirt - Dion Cools #21 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2015-2016 Away shirt worn by or printed for Dion Cools number 21">
+                </figure>
+
             </div>
             <div class="player-info">Player: Dion Cools - Number: 21</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2015-2016</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Dion Cools</dd><dt>Number</dt><dd>21</dd></dl>
+        </article>
+
         <!-- Shirt 87 (ID: 49) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2015-2016 GK 1 - Size: 2XL</h3>
+        <article id="shirt-49" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2015-2016 GK 1 shirt">
+            <meta itemprop="description" content="Club Brugge 2015-2016 GK 1 shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2015-2016, GK 1">
+            <h3>Club Brugge 2015-2016 GK 1 shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt113.1.jpg" alt="Club Brugge 2015-2016 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt113.2.jpg" alt="Club Brugge 2015-2016 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt113.1.jpg" alt="Club Brugge 2015-2016 GK 1 shirt" title="Club Brugge 2015-2016 GK 1 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2015-2016 GK 1 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt113.2.jpg" alt="Club Brugge 2015-2016 GK 1 shirt" title="Club Brugge 2015-2016 GK 1 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2015-2016 GK 1 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2015-2016</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 88 (ID: 48) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2014-2015 Home - Size: M</h3>
+        <article id="shirt-48" class="shirt-section" data-player="nikola storm" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2014-2015 Home shirt - Nikola Storm #42">
+            <meta itemprop="description" content="Club Brugge 2014-2015 Home shirt - Nikola Storm #42, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2014-2015, Home, Nikola Storm, 42">
+            <h3>Club Brugge 2014-2015 Home shirt - Nikola Storm #42 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt97.1.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt97.2.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt97.1.jpg" alt="Club Brugge 2014-2015 Home shirt worn by or printed for Nikola Storm number 42" title="Club Brugge 2014-2015 Home shirt - Nikola Storm #42 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt worn by or printed for Nikola Storm number 42">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt97.2.jpg" alt="Club Brugge 2014-2015 Home shirt worn by or printed for Nikola Storm number 42" title="Club Brugge 2014-2015 Home shirt - Nikola Storm #42 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt worn by or printed for Nikola Storm number 42">
+                </figure>
+
             </div>
             <div class="player-info">Player: Nikola Storm - Number: 42</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2014-2015</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Nikola Storm</dd><dt>Number</dt><dd>42</dd></dl>
+        </article>
+
         <!-- Shirt 89 (ID: 47) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2014-2015 Home - Size: XL</h3>
+        <article id="shirt-47" class="shirt-section" data-collectible="signed" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2014-2015 Home shirt - #12">
+            <meta itemprop="description" content="Club Brugge 2014-2015 Home shirt - #12, Size XL, Signed, signed by Squad signed.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2014-2015, Home, 12, Signed">
+            <h3>Club Brugge 2014-2015 Home shirt - #12 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt70.1.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt70.2.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt70.3.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt70.1.jpg" alt="Club Brugge 2014-2015 Home shirt number 12 Signed" title="Club Brugge 2014-2015 Home shirt - #12 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt number 12 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt70.2.jpg" alt="Club Brugge 2014-2015 Home shirt number 12 Signed" title="Club Brugge 2014-2015 Home shirt - #12 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt number 12 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt70.3.jpg" alt="Club Brugge 2014-2015 Home shirt number 12 Signed" title="Club Brugge 2014-2015 Home shirt - #12 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt number 12 Signed">
+                </figure>
+
             </div>
+            <div class="player-info">Number: 12</div>
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2014-2015</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Number</dt><dd>12</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Squad signed</dd></dl>
+        </article>
+
         <!-- Shirt 90 (ID: 46) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2014-2015 Home - Size: L</h3>
+        <article id="shirt-46" class="shirt-section" data-player="davy de fauw" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2014-2015 Home shirt - Davy De Fauw #2">
+            <meta itemprop="description" content="Club Brugge 2014-2015 Home shirt - Davy De Fauw #2, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2014-2015, Home, Davy De Fauw, 2">
+            <h3>Club Brugge 2014-2015 Home shirt - Davy De Fauw #2 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt26.1.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt26.2.jpg" alt="Club Brugge 2014-2015 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt26.1.jpg" alt="Club Brugge 2014-2015 Home shirt worn by or printed for Davy De Fauw number 2" title="Club Brugge 2014-2015 Home shirt - Davy De Fauw #2 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt worn by or printed for Davy De Fauw number 2">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt26.2.jpg" alt="Club Brugge 2014-2015 Home shirt worn by or printed for Davy De Fauw number 2" title="Club Brugge 2014-2015 Home shirt - Davy De Fauw #2 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Home shirt worn by or printed for Davy De Fauw number 2">
+                </figure>
+
             </div>
             <div class="player-info">Player: Davy De Fauw - Number: 2</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2014-2015</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Davy De Fauw</dd><dt>Number</dt><dd>2</dd></dl>
+        </article>
+
         <!-- Shirt 91 (ID: 45) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2014-2015 Away - Size: 2XL</h3>
+        <article id="shirt-45" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2014-2015 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2014-2015 Away shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2014-2015, Away">
+            <h3>Club Brugge 2014-2015 Away shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt82.1.jpg" alt="Club Brugge 2014-2015 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt82.2.jpg" alt="Club Brugge 2014-2015 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt82.1.jpg" alt="Club Brugge 2014-2015 Away shirt" title="Club Brugge 2014-2015 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt82.2.jpg" alt="Club Brugge 2014-2015 Away shirt" title="Club Brugge 2014-2015 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2014-2015 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2014-2015</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 92 (ID: 44) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2013-2014 Home - Size: L</h3>
+        <article id="shirt-44" class="shirt-section" data-collectible="signed" data-player="tom de sutter" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9">
+            <meta itemprop="description" content="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9, Size L, Signed, signed by Tom De Sutter.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2013-2014, Home, Tom De Sutter, 9, Signed">
+            <h3>Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt25.1.jpg" alt="Club Brugge 2013-2014 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt25.2.jpg" alt="Club Brugge 2013-2014 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt25.1.jpg" alt="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9 Signed" title="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt25.2.jpg" alt="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9 Signed" title="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Tom De Sutter - Number: 9</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2013-2014</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Tom De Sutter</dd><dt>Number</dt><dd>9</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Tom De Sutter</dd></dl>
+        </article>
+
         <!-- Shirt 93 (ID: 43) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2013-2014 Home - Size: XL</h3>
+        <article id="shirt-43" class="shirt-section" data-player="tom de sutter" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9">
+            <meta itemprop="description" content="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2013-2014, Home, Tom De Sutter, 9">
+            <h3>Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt95.1.jpg" alt="Club Brugge 2013-2014 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt95.2.jpg" alt="Club Brugge 2013-2014 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt95.1.jpg" alt="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9" title="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt95.2.jpg" alt="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9" title="Club Brugge 2013-2014 Home shirt - Tom De Sutter #9 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Home shirt worn by or printed for Tom De Sutter number 9">
+                </figure>
+
             </div>
             <div class="player-info">Player: Tom De Sutter - Number: 9</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2013-2014</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Tom De Sutter</dd><dt>Number</dt><dd>9</dd></dl>
+        </article>
+
         <!-- Shirt 94 (ID: 42) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2013-2014 Away - Size: L</h3>
+        <article id="shirt-42" class="shirt-section" data-player="waldemar sobota" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17">
+            <meta itemprop="description" content="Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2013-2014, Away, Waldemar Sobota, 17">
+            <h3>Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt24.1.jpg" alt="Club Brugge 2013-2014 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt24.2.jpg" alt="Club Brugge 2013-2014 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt24.1.jpg" alt="Club Brugge 2013-2014 Away shirt worn by or printed for Waldemar Sobota number 17" title="Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Away shirt worn by or printed for Waldemar Sobota number 17">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt24.2.jpg" alt="Club Brugge 2013-2014 Away shirt worn by or printed for Waldemar Sobota number 17" title="Club Brugge 2013-2014 Away shirt - Waldemar Sobota #17 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Away shirt worn by or printed for Waldemar Sobota number 17">
+                </figure>
+
             </div>
             <div class="player-info">Player: Waldemar Sobota - Number: 17</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2013-2014</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Waldemar Sobota</dd><dt>Number</dt><dd>17</dd></dl>
+        </article>
+
         <!-- Shirt 95 (ID: 41) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2013-2014 Third - Size: 2XL</h3>
+        <article id="shirt-41" class="shirt-section" data-player="nicolás castillo" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30">
+            <meta itemprop="description" content="Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2013-2014, Third, Nicolás Castillo, 30">
+            <h3>Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt94.1.jpg" alt="Club Brugge 2013-2014 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt94.2.jpg" alt="Club Brugge 2013-2014 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt94.1.jpg" alt="Club Brugge 2013-2014 Third shirt worn by or printed for Nicolás Castillo number 30" title="Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Third shirt worn by or printed for Nicolás Castillo number 30">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt94.2.jpg" alt="Club Brugge 2013-2014 Third shirt worn by or printed for Nicolás Castillo number 30" title="Club Brugge 2013-2014 Third shirt - Nicolás Castillo #30 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Third shirt worn by or printed for Nicolás Castillo number 30">
+                </figure>
+
             </div>
             <div class="player-info">Player: Nicolás Castillo - Number: 30</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2013-2014</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Nicolás Castillo</dd><dt>Number</dt><dd>30</dd></dl>
+        </article>
+
         <!-- Shirt 96 (ID: 40) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2013-2014 Third - Size: L</h3>
+        <article id="shirt-40" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2013-2014 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2013-2014 Third shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2013-2014, Third">
+            <h3>Club Brugge 2013-2014 Third shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt93.1.jpg" alt="Club Brugge 2013-2014 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt93.2.jpg" alt="Club Brugge 2013-2014 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt93.1.jpg" alt="Club Brugge 2013-2014 Third shirt" title="Club Brugge 2013-2014 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Third shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt93.2.jpg" alt="Club Brugge 2013-2014 Third shirt" title="Club Brugge 2013-2014 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2013-2014 Third shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2013-2014</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 97 (ID: 39) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2012-2013 Home - Size: XL</h3>
+        <article id="shirt-39" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2012-2013 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2012-2013 Home shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2012-2013, Home">
+            <h3>Club Brugge 2012-2013 Home shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt91.1.jpg" alt="Club Brugge 2012-2013 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt91.2.jpg" alt="Club Brugge 2012-2013 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt91.1.jpg" alt="Club Brugge 2012-2013 Home shirt" title="Club Brugge 2012-2013 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt91.2.jpg" alt="Club Brugge 2012-2013 Home shirt" title="Club Brugge 2012-2013 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2012-2013</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 98 (ID: 38) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2012-2013 Away - Size: L</h3>
+        <article id="shirt-38" class="shirt-section" data-player="carl hoefkens" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4">
+            <meta itemprop="description" content="Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2012-2013, Away, Carl Hoefkens, 4">
+            <h3>Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt20.1.jpg" alt="Club Brugge 2012-2013 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt20.2.jpg" alt="Club Brugge 2012-2013 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt20.3.jpg" alt="Club Brugge 2012-2013 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt20.1.jpg" alt="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4" title="Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt20.2.jpg" alt="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4" title="Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt20.3.jpg" alt="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4" title="Club Brugge 2012-2013 Away shirt - Carl Hoefkens #4 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 Away shirt worn by or printed for Carl Hoefkens number 4">
+                </figure>
+
             </div>
             <div class="player-info">Player: Carl Hoefkens - Number: 4</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2012-2013</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Carl Hoefkens</dd><dt>Number</dt><dd>4</dd></dl>
+        </article>
+
         <!-- Shirt 99 (ID: 37) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2012-2013 GK 2 - Size: L</h3>
+        <article id="shirt-37" class="shirt-section" data-player="bojan jorgačević" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39">
+            <meta itemprop="description" content="Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2012-2013, GK 2, Bojan Jorgačević, 39">
+            <h3>Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt19.1.jpg" alt="Club Brugge 2012-2013 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt19.2.jpg" alt="Club Brugge 2012-2013 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt19.1.jpg" alt="Club Brugge 2012-2013 GK 2 shirt worn by or printed for Bojan Jorgačević number 39" title="Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 GK 2 shirt worn by or printed for Bojan Jorgačević number 39">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt19.2.jpg" alt="Club Brugge 2012-2013 GK 2 shirt worn by or printed for Bojan Jorgačević number 39" title="Club Brugge 2012-2013 GK 2 shirt - Bojan Jorgačević #39 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2012-2013 GK 2 shirt worn by or printed for Bojan Jorgačević number 39">
+                </figure>
+
             </div>
             <div class="player-info">Player: Bojan Jorgačević - Number: 39</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2012-2013</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Bojan Jorgačević</dd><dt>Number</dt><dd>39</dd></dl>
+        </article>
+
         <!-- Shirt 100 (ID: 36) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2011-2012 Home - Size: L</h3>
+        <article id="shirt-36" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2011-2012 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2011-2012 Home shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2011-2012, Home">
+            <h3>Club Brugge 2011-2012 Home shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt128.1.jpg" alt="Club Brugge 2011-2012 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt128.2.jpg" alt="Club Brugge 2011-2012 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt128.1.jpg" alt="Club Brugge 2011-2012 Home shirt" title="Club Brugge 2011-2012 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2011-2012 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt128.2.jpg" alt="Club Brugge 2011-2012 Home shirt" title="Club Brugge 2011-2012 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2011-2012 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2011-2012</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 101 (ID: 35) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2011-2012 Away - Size: L</h3>
+        <article id="shirt-35" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2011-2012 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2011-2012 Away shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2011-2012, Away">
+            <h3>Club Brugge 2011-2012 Away shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt4.1.jpg" alt="Club Brugge 2011-2012 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt4.2.jpg" alt="Club Brugge 2011-2012 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt4.1.jpg" alt="Club Brugge 2011-2012 Away shirt" title="Club Brugge 2011-2012 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2011-2012 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt4.2.jpg" alt="Club Brugge 2011-2012 Away shirt" title="Club Brugge 2011-2012 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2011-2012 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2011-2012</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 102 (ID: 34) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2010-2011 Home - Size: 3XL</h3>
+        <article id="shirt-34" class="shirt-section" data-player="joseph akpala" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2010-2011 Home shirt - Joseph Akpala #15">
+            <meta itemprop="description" content="Club Brugge 2010-2011 Home shirt - Joseph Akpala #15, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2010-2011, Home, Joseph Akpala, 15">
+            <h3>Club Brugge 2010-2011 Home shirt - Joseph Akpala #15 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt90.1.jpg" alt="Club Brugge 2010-2011 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt90.2.jpg" alt="Club Brugge 2010-2011 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt90.1.jpg" alt="Club Brugge 2010-2011 Home shirt worn by or printed for Joseph Akpala number 15" title="Club Brugge 2010-2011 Home shirt - Joseph Akpala #15 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Home shirt worn by or printed for Joseph Akpala number 15">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt90.2.jpg" alt="Club Brugge 2010-2011 Home shirt worn by or printed for Joseph Akpala number 15" title="Club Brugge 2010-2011 Home shirt - Joseph Akpala #15 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Home shirt worn by or printed for Joseph Akpala number 15">
+                </figure>
+
             </div>
             <div class="player-info">Player: Joseph Akpala - Number: 15</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2010-2011</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Joseph Akpala</dd><dt>Number</dt><dd>15</dd></dl>
+        </article>
+
         <!-- Shirt 103 (ID: 33) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2010-2011 Home - Size: XL</h3>
+        <article id="shirt-33" class="shirt-section" data-player="ivan perišić" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2010-2011 Home shirt - Ivan Perišić #44">
+            <meta itemprop="description" content="Club Brugge 2010-2011 Home shirt - Ivan Perišić #44, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2010-2011, Home, Ivan Perišić, 44">
+            <h3>Club Brugge 2010-2011 Home shirt - Ivan Perišić #44 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt17.1.jpg" alt="Club Brugge 2010-2011 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt17.2.jpg" alt="Club Brugge 2010-2011 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt17.3.jpg" alt="Club Brugge 2010-2011 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt17.1.jpg" alt="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44" title="Club Brugge 2010-2011 Home shirt - Ivan Perišić #44 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt17.2.jpg" alt="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44" title="Club Brugge 2010-2011 Home shirt - Ivan Perišić #44 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt17.3.jpg" alt="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44" title="Club Brugge 2010-2011 Home shirt - Ivan Perišić #44 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Home shirt worn by or printed for Ivan Perišić number 44">
+                </figure>
+
             </div>
             <div class="player-info">Player: Ivan Perišić - Number: 44</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2010-2011</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Ivan Perišić</dd><dt>Number</dt><dd>44</dd></dl>
+        </article>
+
         <!-- Shirt 104 (ID: 32) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2010-2011 Away - Size: L</h3>
+        <article id="shirt-32" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2010-2011 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2010-2011 Away shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2010-2011, Away">
+            <h3>Club Brugge 2010-2011 Away shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt16.1.jpg" alt="Club Brugge 2010-2011 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt16.2.jpg" alt="Club Brugge 2010-2011 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt16.1.jpg" alt="Club Brugge 2010-2011 Away shirt" title="Club Brugge 2010-2011 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt16.2.jpg" alt="Club Brugge 2010-2011 Away shirt" title="Club Brugge 2010-2011 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2010-2011</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 105 (ID: 31) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2010-2011 GK 1 - Size: XL</h3>
+        <article id="shirt-31" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2010-2011 GK 1 shirt">
+            <meta itemprop="description" content="Club Brugge 2010-2011 GK 1 shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2010-2011, GK 1">
+            <h3>Club Brugge 2010-2011 GK 1 shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt103.1.jpg" alt="Club Brugge 2010-2011 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt103.2.jpg" alt="Club Brugge 2010-2011 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt103.1.jpg" alt="Club Brugge 2010-2011 GK 1 shirt" title="Club Brugge 2010-2011 GK 1 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 GK 1 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt103.2.jpg" alt="Club Brugge 2010-2011 GK 1 shirt" title="Club Brugge 2010-2011 GK 1 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 GK 1 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2010-2011</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 106 (ID: 30) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2010-2011 GK 2 - Size: M</h3>
+        <article id="shirt-30" class="shirt-section" data-player="colin coosemans" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1">
+            <meta itemprop="description" content="Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2010-2011, GK 2, Colin Coosemans, 1">
+            <h3>Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt129.1.jpg" alt="Club Brugge 2010-2011 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt129.2.jpg" alt="Club Brugge 2010-2011 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt129.1.jpg" alt="Club Brugge 2010-2011 GK 2 shirt worn by or printed for Colin Coosemans number 1" title="Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 GK 2 shirt worn by or printed for Colin Coosemans number 1">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt129.2.jpg" alt="Club Brugge 2010-2011 GK 2 shirt worn by or printed for Colin Coosemans number 1" title="Club Brugge 2010-2011 GK 2 shirt - Colin Coosemans #1 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2010-2011 GK 2 shirt worn by or printed for Colin Coosemans number 1">
+                </figure>
+
             </div>
             <div class="player-info">Player: Colin Coosemans - Number: 1</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2010-2011</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Colin Coosemans</dd><dt>Number</dt><dd>1</dd></dl>
+        </article>
+
         <!-- Shirt 107 (ID: 29) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2009-2010 Home - Size: L</h3>
+        <article id="shirt-29" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2009-2010 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2009-2010 Home shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2009-2010, Home">
+            <h3>Club Brugge 2009-2010 Home shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt15.1.jpg" alt="Club Brugge 2009-2010 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt15.2.jpg" alt="Club Brugge 2009-2010 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt15.1.jpg" alt="Club Brugge 2009-2010 Home shirt" title="Club Brugge 2009-2010 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt15.2.jpg" alt="Club Brugge 2009-2010 Home shirt" title="Club Brugge 2009-2010 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2009-2010</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 108 (ID: 28) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2009-2010 Away - Size: M</h3>
+        <article id="shirt-28" class="shirt-section" data-collectible="signed" data-player="vadis odjidja-ofoe" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32">
+            <meta itemprop="description" content="Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32, Size M, Signed, signed by Vadis Odjidja-Ofoe.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2009-2010, Away, Vadis Odjidja-Ofoe, 32, Signed">
+            <h3>Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt130.1.jpg" alt="Club Brugge 2009-2010 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt130.2.jpg" alt="Club Brugge 2009-2010 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt130.1.jpg" alt="Club Brugge 2009-2010 Away shirt worn by or printed for Vadis Odjidja-Ofoe number 32 Signed" title="Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 Away shirt worn by or printed for Vadis Odjidja-Ofoe number 32 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt130.2.jpg" alt="Club Brugge 2009-2010 Away shirt worn by or printed for Vadis Odjidja-Ofoe number 32 Signed" title="Club Brugge 2009-2010 Away shirt - Vadis Odjidja-Ofoe #32 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 Away shirt worn by or printed for Vadis Odjidja-Ofoe number 32 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Vadis Odjidja-Ofoe - Number: 32</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2009-2010</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Vadis Odjidja-Ofoe</dd><dt>Number</dt><dd>32</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Vadis Odjidja-Ofoe</dd></dl>
+        </article>
+
         <!-- Shirt 109 (ID: 27) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2009-2010 GK 2 - Size: S</h3>
+        <article id="shirt-27" class="shirt-section" data-player="stijn stijnen" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1">
+            <meta itemprop="description" content="Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1, Size S.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2009-2010, GK 2, Stijn Stijnen, 1">
+            <h3>Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1 - Size: S</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt13.1.jpg" alt="Club Brugge 2009-2010 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt13.2.jpg" alt="Club Brugge 2009-2010 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt13.1.jpg" alt="Club Brugge 2009-2010 GK 2 shirt worn by or printed for Stijn Stijnen number 1" title="Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 GK 2 shirt worn by or printed for Stijn Stijnen number 1">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt13.2.jpg" alt="Club Brugge 2009-2010 GK 2 shirt worn by or printed for Stijn Stijnen number 1" title="Club Brugge 2009-2010 GK 2 shirt - Stijn Stijnen #1 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2009-2010 GK 2 shirt worn by or printed for Stijn Stijnen number 1">
+                </figure>
+
             </div>
             <div class="player-info">Player: Stijn Stijnen - Number: 1</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2009-2010</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>S</dd><dt>Player</dt><dd>Stijn Stijnen</dd><dt>Number</dt><dd>1</dd></dl>
+        </article>
+
         <!-- Shirt 110 (ID: 26) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2008-2009 Home - Size: L</h3>
+        <article id="shirt-26" class="shirt-section" data-collectible="signed" data-player="jeroen simaeys" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14">
+            <meta itemprop="description" content="Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14, Size L, Signed, signed by Squad signed.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2008-2009, Home, Jeroen Simaeys, 14, Signed">
+            <h3>Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt75.1.jpg" alt="Club Brugge 2008-2009 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt75.2.jpg" alt="Club Brugge 2008-2009 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt75.1.jpg" alt="Club Brugge 2008-2009 Home shirt worn by or printed for Jeroen Simaeys number 14 Signed" title="Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Home shirt worn by or printed for Jeroen Simaeys number 14 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt75.2.jpg" alt="Club Brugge 2008-2009 Home shirt worn by or printed for Jeroen Simaeys number 14 Signed" title="Club Brugge 2008-2009 Home shirt - Jeroen Simaeys #14 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Home shirt worn by or printed for Jeroen Simaeys number 14 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Jeroen Simaeys - Number: 14</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2008-2009</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Player</dt><dd>Jeroen Simaeys</dd><dt>Number</dt><dd>14</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Squad signed</dd></dl>
+        </article>
+
         <!-- Shirt 111 (ID: 25) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2008-2009 Home - Size: 3XL</h3>
+        <article id="shirt-25" class="shirt-section" data-player="karel geraerts" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2008-2009 Home shirt - Karel Geraerts #22">
+            <meta itemprop="description" content="Club Brugge 2008-2009 Home shirt - Karel Geraerts #22, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2008-2009, Home, Karel Geraerts, 22">
+            <h3>Club Brugge 2008-2009 Home shirt - Karel Geraerts #22 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt104.1.jpg" alt="Club Brugge 2008-2009 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt104.2.jpg" alt="Club Brugge 2008-2009 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt104.1.jpg" alt="Club Brugge 2008-2009 Home shirt worn by or printed for Karel Geraerts number 22" title="Club Brugge 2008-2009 Home shirt - Karel Geraerts #22 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Home shirt worn by or printed for Karel Geraerts number 22">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt104.2.jpg" alt="Club Brugge 2008-2009 Home shirt worn by or printed for Karel Geraerts number 22" title="Club Brugge 2008-2009 Home shirt - Karel Geraerts #22 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Home shirt worn by or printed for Karel Geraerts number 22">
+                </figure>
+
             </div>
             <div class="player-info">Player: Karel Geraerts - Number: 22</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2008-2009</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Karel Geraerts</dd><dt>Number</dt><dd>22</dd></dl>
+        </article>
+
         <!-- Shirt 112 (ID: 24) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2008-2009 Away - Size: 2XL</h3>
+        <article id="shirt-24" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2008-2009 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2008-2009 Away shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2008-2009, Away">
+            <h3>Club Brugge 2008-2009 Away shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt12.1.jpg" alt="Club Brugge 2008-2009 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt12.2.jpg" alt="Club Brugge 2008-2009 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt12.1.jpg" alt="Club Brugge 2008-2009 Away shirt" title="Club Brugge 2008-2009 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt12.2.jpg" alt="Club Brugge 2008-2009 Away shirt" title="Club Brugge 2008-2009 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2008-2009</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 113 (ID: 23) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2008-2009 Third - Size: L</h3>
+        <article id="shirt-23" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2008-2009 Third shirt">
+            <meta itemprop="description" content="Club Brugge 2008-2009 Third shirt, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2008-2009, Third">
+            <h3>Club Brugge 2008-2009 Third shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt11.1.jpg" alt="Club Brugge 2008-2009 Third shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt11.2.jpg" alt="Club Brugge 2008-2009 Third shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt11.1.jpg" alt="Club Brugge 2008-2009 Third shirt" title="Club Brugge 2008-2009 Third shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Third shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt11.2.jpg" alt="Club Brugge 2008-2009 Third shirt" title="Club Brugge 2008-2009 Third shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2008-2009 Third shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2008-2009</dd><dt>Type</dt><dd>Third</dd><dt>Size</dt><dd>L</dd></dl>
+        </article>
+
         <!-- Shirt 114 (ID: 22) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2007-2008 Home - Size: 3XL</h3>
+        <article id="shirt-22" class="shirt-section" data-player="wesley sonck" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2007-2008 Home shirt - Wesley Sonck #10">
+            <meta itemprop="description" content="Club Brugge 2007-2008 Home shirt - Wesley Sonck #10, Size 3XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2007-2008, Home, Wesley Sonck, 10">
+            <h3>Club Brugge 2007-2008 Home shirt - Wesley Sonck #10 - Size: 3XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt74.1.jpg" alt="Club Brugge 2007-2008 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt74.2.jpg" alt="Club Brugge 2007-2008 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt74.1.jpg" alt="Club Brugge 2007-2008 Home shirt worn by or printed for Wesley Sonck number 10" title="Club Brugge 2007-2008 Home shirt - Wesley Sonck #10 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2007-2008 Home shirt worn by or printed for Wesley Sonck number 10">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt74.2.jpg" alt="Club Brugge 2007-2008 Home shirt worn by or printed for Wesley Sonck number 10" title="Club Brugge 2007-2008 Home shirt - Wesley Sonck #10 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2007-2008 Home shirt worn by or printed for Wesley Sonck number 10">
+                </figure>
+
             </div>
             <div class="player-info">Player: Wesley Sonck - Number: 10</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2007-2008</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>3XL</dd><dt>Player</dt><dd>Wesley Sonck</dd><dt>Number</dt><dd>10</dd></dl>
+        </article>
+
         <!-- Shirt 115 (ID: 21) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2007-2008 Away - Size: S</h3>
+        <article id="shirt-21" class="shirt-section" data-player="françois sterchele" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2007-2008 Away shirt - François Sterchele #23">
+            <meta itemprop="description" content="Club Brugge 2007-2008 Away shirt - François Sterchele #23, Size S.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2007-2008, Away, François Sterchele, 23">
+            <h3>Club Brugge 2007-2008 Away shirt - François Sterchele #23 - Size: S</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt10.1.jpg" alt="Club Brugge 2007-2008 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt10.2.jpg" alt="Club Brugge 2007-2008 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt10.1.jpg" alt="Club Brugge 2007-2008 Away shirt worn by or printed for François Sterchele number 23" title="Club Brugge 2007-2008 Away shirt - François Sterchele #23 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2007-2008 Away shirt worn by or printed for François Sterchele number 23">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt10.2.jpg" alt="Club Brugge 2007-2008 Away shirt worn by or printed for François Sterchele number 23" title="Club Brugge 2007-2008 Away shirt - François Sterchele #23 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2007-2008 Away shirt worn by or printed for François Sterchele number 23">
+                </figure>
+
             </div>
             <div class="player-info">Player: François Sterchele - Number: 23</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2007-2008</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>S</dd><dt>Player</dt><dd>François Sterchele</dd><dt>Number</dt><dd>23</dd></dl>
+        </article>
+
         <!-- Shirt 116 (ID: 20) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2006-2007 Away - Size: XL</h3>
+        <article id="shirt-20" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2006-2007 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2006-2007 Away shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2006-2007, Away">
+            <h3>Club Brugge 2006-2007 Away shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt8.1.jpg" alt="Club Brugge 2006-2007 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt8.2.jpg" alt="Club Brugge 2006-2007 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt8.1.jpg" alt="Club Brugge 2006-2007 Away shirt" title="Club Brugge 2006-2007 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2006-2007 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt8.2.jpg" alt="Club Brugge 2006-2007 Away shirt" title="Club Brugge 2006-2007 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2006-2007 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2006-2007</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 117 (ID: 19) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2006-2007 GK 2 - Size: L</h3>
+        <article id="shirt-19" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2006-2007 GK 2 shirt - #23">
+            <meta itemprop="description" content="Club Brugge 2006-2007 GK 2 shirt - #23, Size L.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2006-2007, GK 2, 23">
+            <h3>Club Brugge 2006-2007 GK 2 shirt - #23 - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt51.1.jpg" alt="Club Brugge 2006-2007 GK 2 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt51.2.jpg" alt="Club Brugge 2006-2007 GK 2 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt51.1.jpg" alt="Club Brugge 2006-2007 GK 2 shirt number 23" title="Club Brugge 2006-2007 GK 2 shirt - #23 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2006-2007 GK 2 shirt number 23">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt51.2.jpg" alt="Club Brugge 2006-2007 GK 2 shirt number 23" title="Club Brugge 2006-2007 GK 2 shirt - #23 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2006-2007 GK 2 shirt number 23">
+                </figure>
+
             </div>
-        </div>
-        
+            <div class="player-info">Number: 23</div>
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2006-2007</dd><dt>Type</dt><dd>GK 2</dd><dt>Size</dt><dd>L</dd><dt>Number</dt><dd>23</dd></dl>
+        </article>
+
         <!-- Shirt 118 (ID: 18) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2005-2007 Home - Size: XL</h3>
+        <article id="shirt-18" class="shirt-section" data-player="brian priske" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2005-2007 Home shirt - Brian Priske #24">
+            <meta itemprop="description" content="Club Brugge 2005-2007 Home shirt - Brian Priske #24, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2005-2007, Home, Brian Priske, 24">
+            <h3>Club Brugge 2005-2007 Home shirt - Brian Priske #24 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt9.1.jpg" alt="Club Brugge 2005-2007 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt9.2.jpg" alt="Club Brugge 2005-2007 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt9.1.jpg" alt="Club Brugge 2005-2007 Home shirt worn by or printed for Brian Priske number 24" title="Club Brugge 2005-2007 Home shirt - Brian Priske #24 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2005-2007 Home shirt worn by or printed for Brian Priske number 24">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt9.2.jpg" alt="Club Brugge 2005-2007 Home shirt worn by or printed for Brian Priske number 24" title="Club Brugge 2005-2007 Home shirt - Brian Priske #24 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2005-2007 Home shirt worn by or printed for Brian Priske number 24">
+                </figure>
+
             </div>
             <div class="player-info">Player: Brian Priske - Number: 24</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2005-2007</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Player</dt><dd>Brian Priske</dd><dt>Number</dt><dd>24</dd></dl>
+        </article>
+
         <!-- Shirt 119 (ID: 17) -->
-        <div class="shirt-section" data-collectible="signed">
-            <h3>Club Brugge 2004-2006 Away - Size: 2XL</h3>
+        <article id="shirt-17" class="shirt-section" data-collectible="signed" data-player="gert verheyen" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2004-2006 Away shirt - Gert Verheyen #7">
+            <meta itemprop="description" content="Club Brugge 2004-2006 Away shirt - Gert Verheyen #7, Size 2XL, Signed, signed by Gert Verheyen.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2004-2006, Away, Gert Verheyen, 7, Signed">
+            <h3>Club Brugge 2004-2006 Away shirt - Gert Verheyen #7 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt7.1.jpg" alt="Club Brugge 2004-2006 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt7.2.jpg" alt="Club Brugge 2004-2006 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt7.3.jpg" alt="Club Brugge 2004-2006 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt7.1.jpg" alt="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed" title="Club Brugge 2004-2006 Away shirt - Gert Verheyen #7 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt7.2.jpg" alt="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed" title="Club Brugge 2004-2006 Away shirt - Gert Verheyen #7 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt7.3.jpg" alt="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed" title="Club Brugge 2004-2006 Away shirt - Gert Verheyen #7 photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2004-2006 Away shirt worn by or printed for Gert Verheyen number 7 Signed">
+                </figure>
+
             </div>
             <div class="player-info">Player: Gert Verheyen - Number: 7</div>
-            
+
             <div class="collectible-info">Status: Signed</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2004-2006</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd><dt>Player</dt><dd>Gert Verheyen</dd><dt>Number</dt><dd>7</dd><dt>Status</dt><dd>Signed</dd><dt>Signatures</dt><dd>Gert Verheyen</dd></dl>
+        </article>
+
         <!-- Shirt 120 (ID: 16) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2004-2005 GK 1 - Size: XL</h3>
+        <article id="shirt-16" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2004-2005 GK 1 shirt">
+            <meta itemprop="description" content="Club Brugge 2004-2005 GK 1 shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2004-2005, GK 1">
+            <h3>Club Brugge 2004-2005 GK 1 shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt6.1.jpg" alt="Club Brugge 2004-2005 GK 1 shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt6.2.jpg" alt="Club Brugge 2004-2005 GK 1 shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt6.1.jpg" alt="Club Brugge 2004-2005 GK 1 shirt" title="Club Brugge 2004-2005 GK 1 shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2004-2005 GK 1 shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt6.2.jpg" alt="Club Brugge 2004-2005 GK 1 shirt" title="Club Brugge 2004-2005 GK 1 shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2004-2005 GK 1 shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2004-2005</dd><dt>Type</dt><dd>GK 1</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 121 (ID: 15) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2003-2004 Away - Size: XL</h3>
+        <article id="shirt-15" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2003-2004 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2003-2004 Away shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2003-2004, Away">
+            <h3>Club Brugge 2003-2004 Away shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt42.1.jpg" alt="Club Brugge 2003-2004 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt42.2.jpg" alt="Club Brugge 2003-2004 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt42.1.jpg" alt="Club Brugge 2003-2004 Away shirt" title="Club Brugge 2003-2004 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2003-2004 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt42.2.jpg" alt="Club Brugge 2003-2004 Away shirt" title="Club Brugge 2003-2004 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2003-2004 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2003-2004</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 122 (ID: 14) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2002-2004 Home - Size: XL</h3>
+        <article id="shirt-14" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2002-2004 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2002-2004 Home shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2002-2004, Home">
+            <h3>Club Brugge 2002-2004 Home shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt89.1.jpg" alt="Club Brugge 2002-2004 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt89.2.jpg" alt="Club Brugge 2002-2004 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt89.1.jpg" alt="Club Brugge 2002-2004 Home shirt" title="Club Brugge 2002-2004 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2002-2004 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt89.2.jpg" alt="Club Brugge 2002-2004 Home shirt" title="Club Brugge 2002-2004 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2002-2004 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2002-2004</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 123 (ID: 13) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2002-2003 Away - Size: M</h3>
+        <article id="shirt-13" class="shirt-section" data-player="timmy simons" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2002-2003 Away shirt - Timmy Simons #3">
+            <meta itemprop="description" content="Club Brugge 2002-2003 Away shirt - Timmy Simons #3, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2002-2003, Away, Timmy Simons, 3">
+            <h3>Club Brugge 2002-2003 Away shirt - Timmy Simons #3 - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt53.1.jpg" alt="Club Brugge 2002-2003 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt53.2.jpg" alt="Club Brugge 2002-2003 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt53.1.jpg" alt="Club Brugge 2002-2003 Away shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2002-2003 Away shirt - Timmy Simons #3 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2002-2003 Away shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt53.2.jpg" alt="Club Brugge 2002-2003 Away shirt worn by or printed for Timmy Simons number 3" title="Club Brugge 2002-2003 Away shirt - Timmy Simons #3 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2002-2003 Away shirt worn by or printed for Timmy Simons number 3">
+                </figure>
+
             </div>
             <div class="player-info">Player: Timmy Simons - Number: 3</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2002-2003</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>M</dd><dt>Player</dt><dd>Timmy Simons</dd><dt>Number</dt><dd>3</dd></dl>
+        </article>
+
         <!-- Shirt 124 (ID: 12) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2000-2002 Home - Size: 2XL</h3>
+        <article id="shirt-12" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2000-2002 Home shirt - #31">
+            <meta itemprop="description" content="Club Brugge 2000-2002 Home shirt - #31, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2000-2002, Home, 31">
+            <h3>Club Brugge 2000-2002 Home shirt - #31 - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt67.1.jpg" alt="Club Brugge 2000-2002 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt67.2.jpg" alt="Club Brugge 2000-2002 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt67.1.jpg" alt="Club Brugge 2000-2002 Home shirt number 31" title="Club Brugge 2000-2002 Home shirt - #31 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Home shirt number 31">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt67.2.jpg" alt="Club Brugge 2000-2002 Home shirt number 31" title="Club Brugge 2000-2002 Home shirt - #31 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Home shirt number 31">
+                </figure>
+
             </div>
-        </div>
-        
+            <div class="player-info">Number: 31</div>
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2000-2002</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>2XL</dd><dt>Number</dt><dd>31</dd></dl>
+        </article>
+
         <!-- Shirt 125 (ID: 11) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2000-2002 Home - Size: XL</h3>
+        <article id="shirt-11" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2000-2002 Home shirt">
+            <meta itemprop="description" content="Club Brugge 2000-2002 Home shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2000-2002, Home">
+            <h3>Club Brugge 2000-2002 Home shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt88.1.jpg" alt="Club Brugge 2000-2002 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt88.2.jpg" alt="Club Brugge 2000-2002 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt88.1.jpg" alt="Club Brugge 2000-2002 Home shirt" title="Club Brugge 2000-2002 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt88.2.jpg" alt="Club Brugge 2000-2002 Home shirt" title="Club Brugge 2000-2002 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2000-2002</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 126 (ID: 10) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 2000-2002 Away - Size: 2XL</h3>
+        <article id="shirt-10" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 2000-2002 Away shirt">
+            <meta itemprop="description" content="Club Brugge 2000-2002 Away shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 2000-2002, Away">
+            <h3>Club Brugge 2000-2002 Away shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt73.1.jpg" alt="Club Brugge 2000-2002 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt73.2.jpg" alt="Club Brugge 2000-2002 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt73.1.jpg" alt="Club Brugge 2000-2002 Away shirt" title="Club Brugge 2000-2002 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt73.2.jpg" alt="Club Brugge 2000-2002 Away shirt" title="Club Brugge 2000-2002 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 2000-2002 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>2000-2002</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 127 (ID: 9) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1999-2000 Home - Size: M</h3>
+        <article id="shirt-9" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1999-2000 Home shirt">
+            <meta itemprop="description" content="Club Brugge 1999-2000 Home shirt, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1999-2000, Home">
+            <h3>Club Brugge 1999-2000 Home shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt3.1.jpg" alt="Club Brugge 1999-2000 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt3.2.jpg" alt="Club Brugge 1999-2000 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt3.1.jpg" alt="Club Brugge 1999-2000 Home shirt" title="Club Brugge 1999-2000 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1999-2000 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt3.2.jpg" alt="Club Brugge 1999-2000 Home shirt" title="Club Brugge 1999-2000 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1999-2000 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1999-2000</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd></dl>
+        </article>
+
         <!-- Shirt 128 (ID: 8) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1998-1999 Home - Size: XL</h3>
+        <article id="shirt-8" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1998-1999 Home shirt">
+            <meta itemprop="description" content="Club Brugge 1998-1999 Home shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1998-1999, Home">
+            <h3>Club Brugge 1998-1999 Home shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt72.1.jpg" alt="Club Brugge 1998-1999 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt72.2.jpg" alt="Club Brugge 1998-1999 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt72.1.jpg" alt="Club Brugge 1998-1999 Home shirt" title="Club Brugge 1998-1999 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1998-1999 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt72.2.jpg" alt="Club Brugge 1998-1999 Home shirt" title="Club Brugge 1998-1999 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1998-1999 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1998-1999</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 129 (ID: 7) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1998-1999 Away - Size: XL</h3>
+        <article id="shirt-7" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1998-1999 Away shirt">
+            <meta itemprop="description" content="Club Brugge 1998-1999 Away shirt, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1998-1999, Away">
+            <h3>Club Brugge 1998-1999 Away shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt96.1.jpg" alt="Club Brugge 1998-1999 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt96.2.jpg" alt="Club Brugge 1998-1999 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt96.3.jpg" alt="Club Brugge 1998-1999 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt96.1.jpg" alt="Club Brugge 1998-1999 Away shirt" title="Club Brugge 1998-1999 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1998-1999 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt96.2.jpg" alt="Club Brugge 1998-1999 Away shirt" title="Club Brugge 1998-1999 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1998-1999 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt96.3.jpg" alt="Club Brugge 1998-1999 Away shirt" title="Club Brugge 1998-1999 Away shirt photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1998-1999 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1998-1999</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>XL</dd></dl>
+        </article>
+
         <!-- Shirt 130 (ID: 6) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1997-1998 Home - Size: XL</h3>
+        <article id="shirt-6" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1997-1998 Home shirt - #23">
+            <meta itemprop="description" content="Club Brugge 1997-1998 Home shirt - #23, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1997-1998, Home, 23">
+            <h3>Club Brugge 1997-1998 Home shirt - #23 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt2.1.jpg" alt="Club Brugge 1997-1998 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt2.2.jpg" alt="Club Brugge 1997-1998 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt2.1.jpg" alt="Club Brugge 1997-1998 Home shirt number 23" title="Club Brugge 1997-1998 Home shirt - #23 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1997-1998 Home shirt number 23">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt2.2.jpg" alt="Club Brugge 1997-1998 Home shirt number 23" title="Club Brugge 1997-1998 Home shirt - #23 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1997-1998 Home shirt number 23">
+                </figure>
+
             </div>
-        </div>
-        
+            <div class="player-info">Number: 23</div>
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1997-1998</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Number</dt><dd>23</dd></dl>
+        </article>
+
         <!-- Shirt 131 (ID: 5) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1996-1997 Home Youth - Size: XL</h3>
+        <article id="shirt-5" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1996-1997 Home Youth shirt - #4">
+            <meta itemprop="description" content="Club Brugge 1996-1997 Home Youth shirt - #4, Size XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1996-1997, Home Youth, 4">
+            <h3>Club Brugge 1996-1997 Home Youth shirt - #4 - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt71.2.jpg" alt="Club Brugge 1996-1997 Home Youth shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt71.1.jpg" alt="Club Brugge 1996-1997 Home Youth shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt71.2.jpg" alt="Club Brugge 1996-1997 Home Youth shirt number 4" title="Club Brugge 1996-1997 Home Youth shirt - #4 photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1996-1997 Home Youth shirt number 4">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt71.1.jpg" alt="Club Brugge 1996-1997 Home Youth shirt number 4" title="Club Brugge 1996-1997 Home Youth shirt - #4 photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1996-1997 Home Youth shirt number 4">
+                </figure>
+
             </div>
-        </div>
-        
+            <div class="player-info">Number: 4</div>
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1996-1997</dd><dt>Type</dt><dd>Home Youth</dd><dt>Size</dt><dd>XL</dd><dt>Number</dt><dd>4</dd></dl>
+        </article>
+
         <!-- Shirt 132 (ID: 4) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1996-1997 Away - Size: 2XL</h3>
+        <article id="shirt-4" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1996-1997 Away shirt">
+            <meta itemprop="description" content="Club Brugge 1996-1997 Away shirt, Size 2XL.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1996-1997, Away">
+            <h3>Club Brugge 1996-1997 Away shirt - Size: 2XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt27.1.jpg" alt="Club Brugge 1996-1997 Away shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt27.2.jpg" alt="Club Brugge 1996-1997 Away shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt27.1.jpg" alt="Club Brugge 1996-1997 Away shirt" title="Club Brugge 1996-1997 Away shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1996-1997 Away shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt27.2.jpg" alt="Club Brugge 1996-1997 Away shirt" title="Club Brugge 1996-1997 Away shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1996-1997 Away shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1996-1997</dd><dt>Type</dt><dd>Away</dd><dt>Size</dt><dd>2XL</dd></dl>
+        </article>
+
         <!-- Shirt 133 (ID: 3) -->
-        <div class="shirt-section">
-            <h3>Club Brugge 1993-1994 Home - Size: M</h3>
+        <article id="shirt-3" class="shirt-section" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1993-1994 Home shirt">
+            <meta itemprop="description" content="Club Brugge 1993-1994 Home shirt, Size M.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1993-1994, Home">
+            <h3>Club Brugge 1993-1994 Home shirt - Size: M</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt131.1.jpg" alt="Club Brugge 1993-1994 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt131.2.jpg" alt="Club Brugge 1993-1994 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt131.3.jpg" alt="Club Brugge 1993-1994 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt131.1.jpg" alt="Club Brugge 1993-1994 Home shirt" title="Club Brugge 1993-1994 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1993-1994 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt131.2.jpg" alt="Club Brugge 1993-1994 Home shirt" title="Club Brugge 1993-1994 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1993-1994 Home shirt">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt131.3.jpg" alt="Club Brugge 1993-1994 Home shirt" title="Club Brugge 1993-1994 Home shirt photo 3" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1993-1994 Home shirt">
+                </figure>
+
             </div>
-        </div>
-        
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1993-1994</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>M</dd></dl>
+        </article>
+
         <!-- Shirt 134 (ID: 2) -->
-        <div class="shirt-section" data-collectible="copa">
-            <h3>Club Brugge 1987-1988 Home - Size: L</h3>
+        <article id="shirt-2" class="shirt-section" data-collectible="copa" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1987-1988 Home shirt">
+            <meta itemprop="description" content="Club Brugge 1987-1988 Home shirt, Size L, Copa.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1987-1988, Home, Copa">
+            <h3>Club Brugge 1987-1988 Home shirt - Size: L</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt114.1.jpg" alt="Club Brugge 1987-1988 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt114.2.jpg" alt="Club Brugge 1987-1988 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt114.1.jpg" alt="Club Brugge 1987-1988 Home shirt Copa" title="Club Brugge 1987-1988 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1987-1988 Home shirt Copa">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt114.2.jpg" alt="Club Brugge 1987-1988 Home shirt Copa" title="Club Brugge 1987-1988 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1987-1988 Home shirt Copa">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Copa</div>
-            
-        </div>
-        
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1987-1988</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>L</dd><dt>Status</dt><dd>Copa</dd></dl>
+        </article>
+
         <!-- Shirt 135 (ID: 1) -->
-        <div class="shirt-section" data-collectible="retro">
-            <h3>Club Brugge 1972-1973 Home - Size: XL</h3>
+        <article id="shirt-1" class="shirt-section" data-collectible="retro" itemscope itemtype="https://schema.org/Product" itemprop="hasPart">
+            <meta itemprop="name" content="Club Brugge 1972-1973 Home shirt">
+            <meta itemprop="description" content="Club Brugge 1972-1973 Home shirt, Size XL, Retro.">
+            <meta itemprop="category" content="Football shirt">
+            <meta itemprop="keywords" content="Club Brugge, 1972-1973, Home, Retro">
+            <h3>Club Brugge 1972-1973 Home shirt - Size: XL</h3>
             <div class="photo-row">
-        
-                <div class="photo">
-                    <img src="./shirtImages/Shirt105.1.jpg" alt="Club Brugge 1972-1973 Home shirt" loading="lazy">
-                </div>
-            
-                <div class="photo">
-                    <img src="./shirtImages/Shirt105.2.jpg" alt="Club Brugge 1972-1973 Home shirt" loading="lazy">
-                </div>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt105.1.jpg" alt="Club Brugge 1972-1973 Home shirt Retro" title="Club Brugge 1972-1973 Home shirt photo 1" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1972-1973 Home shirt Retro">
+                </figure>
+
+                <figure class="photo" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+                    <img src="./shirtImages/Shirt105.2.jpg" alt="Club Brugge 1972-1973 Home shirt Retro" title="Club Brugge 1972-1973 Home shirt photo 2" loading="lazy" itemprop="contentUrl">
+                    <meta itemprop="caption" content="Club Brugge 1972-1973 Home shirt Retro">
+                </figure>
+
             </div>
             <div class="collectible-info">Status: Retro</div>
-            
-        </div>
-        
-            </section>
-        </main>
-    </body>
-    </html>
-    
+
+            <dl class="shirt-metadata" aria-label="Shirt metadata"><dt>Season</dt><dd>1972-1973</dd><dt>Type</dt><dd>Home</dd><dt>Size</dt><dd>XL</dd><dt>Status</dt><dd>Retro</dd></dl>
+        </article>
+
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Maak de automatisch gegenereerde `shirts.html` beter vindbaar en doorzoekbaar door zoekwoorden, spelersnamen en gestructureerde metadata toe te voegen. 
- Zorg dat toekomstige regeneraties vanuit de CSV dezelfde SEO-, Open Graph- en structured-data informatie behouden door de generator (`python/2_csv_to_html.py`) aan te passen.
- Verbeter toegankelijkheid en indexeerbaarheid door betere `alt`/`title` teksten en per-shirt microdata toe te voegen.

### Description
- Brede update van de CSV->HTML generator in `python/2_csv_to_html.py` die cleaning/escaping helpers toevoegt, unieke spelers/seizoenen/shirttypes detecteert en keywords/meta-description opbouwt, plus implementatie van `JSON-LD` (`CollectionPage`, `BreadcrumbList`, `ItemList`) en per-item `Product`-objecten met `additionalProperty`. 
- `shirts.html` is opnieuw gegenereerd en bevat nu: verbeterde `<title>`, `<meta name="description">`, `<meta name="keywords">`, canonical, uitgebreide Open Graph/Twitter tags, `itemscope`/`itemtype` Product markup, en per-shirt metadata (meta tags, image `alt`/`title`, zichtbare `<dl class="shirt-metadata">`).
- Stijlaanpassingen in `css/style.css` om `collection-meta` en `.shirt-metadata` te ondersteunen en layout/kleuren consistent te houden.
- Kleine robustness- en formatting fixes in de generator (first image lookup, whitespace trimming when writing file, slug/escape helpers) zodat her-generatie identiek SEO-metadata produceert.

### Testing
- Ran the generator with `python3 python/2_csv_to_html.py` and it completed successfully. (✅)
- Verified JSON-LD and per-shirt structured data by parsing the `<script type="application/ld+json">` block with Python assertions (checked `@context`, existence of `ItemList` with `numberOfItems == 135`, and presence of sample player names). (✅)
- Served `shirts.html` locally with `python3 -m http.server` and fetched the page with `urllib` to assert presence of SEO `<title>`, `itemscope itemtype="https://schema.org/Product"`, and sample player text; also ran `git diff --check`. All automated checks passed. (✅)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083b53ab1c83259df5b9a7e414c743)